### PR TITLE
guides: create a simple guide as a demo of how to do it!

### DIFF
--- a/_posts/2020-10-07-intro-to-play-with-go-dev_go115_en.markdown
+++ b/_posts/2020-10-07-intro-to-play-with-go-dev_go115_en.markdown
@@ -8,6 +8,8 @@ layout: post
 title: An introduction to play-with-go.dev guides
 ---
 
+Hello &#123;&#123; .world &#125;&#125;
+
 [`play-with-go.dev`](https://play-with-go.dev/) is a series of interactive browser-based guides that lead you on a tour
 of the [Go command](https://golang.org/cmd/go/) and [Go modules](https://golang.org/ref/mod).
 

--- a/contributing/contributing.go
+++ b/contributing/contributing.go
@@ -1,0 +1,5 @@
+// +build contributing
+
+package contributing
+
+//go:generate go run github.com/play-with-go/preguide/cmd/preguide gen -runargs "term1=-v create-your-first-guide:/var --privileged -e GOMODCACHE=/var/gomodcache -e GOCACHE=/var/gocache" -mode github .

--- a/contributing/contributing.markdown
+++ b/contributing/contributing.markdown
@@ -1,0 +1,161 @@
+### Writing your first `play-with-go.dev` guide!
+
+This guide explains how to create your first `play-with-go.dev` guide using the `play-with-go` development environment.
+Guides are first developed locally, then pushed as pull requests to the
+[`play-with-go`](https://github.com/play-with-go/play-with-go) project.
+
+_This_ guide the entire local development process.  Creating a pull request and the review workflow is discussed
+elsewhere (TODO: create a wiki/document).
+
+### Prerequisites
+
+This is &lbrace; &lbrace; a test &rbrace; &rbrace;
+
+This guide assumes you have `docker`, `docker-compose`, `mkcert` and `go` commands available. We will be using uses the
+following versions:
+
+```
+$ docker version -f {% raw %}{{{% endraw %}.Server.Version{% raw %}}}{% endraw %}
+19.03.12
+$ docker-compose version
+docker-compose version 1.26.2, build eefe0d31
+docker-py version: 4.2.2
+CPython version: 3.7.7
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+$ go version
+go version go1.15.1 linux/amd64
+$ mkcert -version
+v1.4.1
+```
+
+### Getting started `play-with-go`
+
+Start by cloning the `play-with-go` project:
+
+```
+$ git clone https://github.com/play-with-go/play-with-go
+Cloning into 'play-with-go'...
+$ cd play-with-go
+```
+
+Create a branch for our changes:
+
+```
+$ git checkout -b myfirstguide 206a134e21007d1970e92be68ed0a2451376208a
+Switched to a new branch 'myfirstguide'
+```
+
+As you can see, we are using commit [`<!--def: playWithGoCommit -->`](https://github.com/play-with-go/play-with-go/tree/206a134e21007d1970e92be68ed0a2451376208a)
+as a known starting point; you can omit this commit if you like which default to using `origin/main`
+
+TODO: make this a guide that demonstrates how to create a guide.
+
+## Terminology and Overall structure
+
+Explain:
+
+* how guides are the result of combinding the markdown prose with a CUE specification of the "steps" in that guide, i.e.
+  the commands the user will run
+* the directory structure currently used by play-with-go, and how this feeds into the Jekyll frontend
+* the concept of the input guide CUE package and the generated output (that can be augmented with guide author
+  declarations)
+* ...
+
+We use the following terminology:
+
+* the user - the end user who is reading and following the guide in a browser, executing the various steps via the PWD
+  console
+* guide author - the person who created the guide
+* `preguide` - is the authoring tool used by the guide author when writing a guide. `preguide` ensures that the steps in
+  a guide can be run and are reproducible
+* remote session - is used to refer to the container that is driving the container that is visualised via the frontend
+  terminal
+* define the terms input and output. Possibly distinguish between the markdown and script input, and markdown and
+  command result output. A diagram?
+
+## Presteps
+
+Presteps are declared by a guide author to run as each guide instance is launched. For example, for this guide we have a
+prestep that creates a unique user account and repository in the source control system that supports the
+`play-with-go.dev/userguides/...` modules. This therefore allows us to create a local `git` repository that uses the
+that remote repository:
+
+<!-- step: create_local_repo -->
+
+Let's add a readme file to explain what this repository is all about:
+
+<!-- step: add_readme -->
+
+Create our initial commit and push to the remote repository:
+
+<!-- step: create_initial_commit -->
+
+
+TODO:
+
+* make this a Go module for a library
+* then create a local Go module that uses the new library and pulls that through the proxy
+* explain that a guide can run multiple presteps, or none
+
+## Different types of step
+
+`preguide` defines two basic steps that a user can perform:
+
+* run a sequence of commands
+* uploading a file
+
+`preguide` exposes these to the guide author as four step types (the reference to the CUE package
+`github.com/play-with-go/preguide` is shortened to simply `preguide`):
+
+* `preguide.#Command` - run a sequence of commands, providing those steps inline with the step declaration
+* `preguide.#CommandFile` - run a sequence of commands, with the steps being sourced from a file
+* `preguide.#Upload` - upload a file to the remote session, providing the files contents inline with the step declaration
+* `preguide.#UploadFile` - upload a file to the remote session, with the file contents being sourced from a file
+
+Within a the markdown prose
+
+## Translations and scenarios
+
+TODO:
+
+Explain that:
+
+* a guide can vary by langauge (i.e. translated into a different language, potentially with different steps specific to
+  that language), and/or
+* a giude can vary by scenario. e.g. a guide is predominantly writtern for Go 1.15, but alternative language (and steps)
+  are provided for Go 1.14 where there are differences
+
+
+## Multiple remote sessions
+
+TODO:
+
+Explain that:
+
+* guides can be written to leverage multiple terminals, i.e. remote sessions. Particularly useful for client-server
+  interaction examples
+
+## Reference directives
+
+Consider the following commands:
+
+<!-- step: random_commands -->
+
+Notice how the step is declared in terms of a `Defs`-declared message. We can reference that message in the prose of a
+guide using a `ref` directive: `<!-- ref: random_message -->`.
+
+Similarly, we can use `outref` directives to refer to the result of executing the guide script. For example, here we
+reference the output from the `<!-- ref: go_env_gopath -->` command directly in our prose: `<!-- outref: go_env_gopath
+-->`.
+
+TODO:
+
+Explain that, as the guide author, you can include `ref` and `outref` directives to reference specific aspects of a
+guide.
+
+`ref` directives refer to `Defs` fields that are defined as part of the _input_ guide CUE package. They can be
+arbitrary string values. Those `Defs` fields are then typically used within step declarations for that guide. Using
+`ref` directives in this way ensures that parts of the guide prose and script stay consistent.
+
+`outref` directives refer to `Defs` fields that are defined as part of the _output_ guide CUE package. This allows
+the guide author to reference specific parts of the output

--- a/contributing/contributing_go115_en.markdown
+++ b/contributing/contributing_go115_en.markdown
@@ -1,0 +1,154 @@
+### Writing your first `play-with-go.dev` guide!
+
+This guide explains how to create your first `play-with-go.dev` guide using the `play-with-go` development environment.
+Guides are first developed locally, then pushed as pull requests to the
+[`play-with-go`](https://github.com/play-with-go/play-with-go) project.
+
+_This_ guide the entire local development process.  Creating a pull request and the review workflow is discussed
+elsewhere (TODO: create a wiki/document).
+
+### Prerequisites
+
+This guide uses the following commands:
+
+<pre><code>$ docker version -f &#123;&#123;.Server.Version&#125;&#125;
+19.03.13
+$ docker-compose version
+docker-compose version 1.26.2, build eefe0d31
+docker-py version: 4.2.2
+CPython version: 3.7.7
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+$ go version
+go version go1.15.5 linux/amd64
+</code></pre>
+
+### Getting started `play-with-go`
+
+Start by cloning the `play-with-go` project:
+
+<pre><code>$ git clone -q https://github.com/play-with-go/play-with-go
+$ cd play-with-go
+$ git checkout simple_guide
+Branch &#39;simple_guide&#39; set up to track remote branch &#39;simple_guide&#39; from &#39;origin&#39;.
+Switched to a new branch &#39;simple_guide&#39;
+</code></pre>
+
+<pre><code>Blah
+</code></pre>
+
+Create a branch for our changes:
+
+As you can see, we are using commit [`<!--def: playWithGoCommit -->`](https://github.com/play-with-go/play-with-go/tree/simple_guide)
+as a known starting point; you can omit this commit if you like which default to using `origin/main`
+
+TODO: make this a guide that demonstrates how to create a guide.
+
+## Terminology and Overall structure
+
+Explain:
+
+* how guides are the result of combinding the markdown prose with a CUE specification of the "steps" in that guide, i.e.
+  the commands the user will run
+* the directory structure currently used by play-with-go, and how this feeds into the Jekyll frontend
+* the concept of the input guide CUE package and the generated output (that can be augmented with guide author
+  declarations)
+* ...
+
+We use the following terminology:
+
+* the user - the end user who is reading and following the guide in a browser, executing the various steps via the PWD
+  console
+* guide author - the person who created the guide
+* `preguide` - is the authoring tool used by the guide author when writing a guide. `preguide` ensures that the steps in
+  a guide can be run and are reproducible
+* remote session - is used to refer to the container that is driving the container that is visualised via the frontend
+  terminal
+* define the terms input and output. Possibly distinguish between the markdown and script input, and markdown and
+  command result output. A diagram?
+
+## Presteps
+
+Presteps are declared by a guide author to run as each guide instance is launched. For example, for this guide we have a
+prestep that creates a unique user account and repository in the source control system that supports the
+`play-with-go.dev/userguides/...` modules. This therefore allows us to create a local `git` repository that uses the
+that remote repository:
+
+<!-- step: create_local_repo -->
+
+Let's add a readme file to explain what this repository is all about:
+
+<!-- step: add_readme -->
+
+Create our initial commit and push to the remote repository:
+
+<!-- step: create_initial_commit -->
+
+
+TODO:
+
+* make this a Go module for a library
+* then create a local Go module that uses the new library and pulls that through the proxy
+* explain that a guide can run multiple presteps, or none
+
+## Different types of step
+
+`preguide` defines two basic steps that a user can perform:
+
+* run a sequence of commands
+* uploading a file
+
+`preguide` exposes these to the guide author as four step types (the reference to the CUE package
+`github.com/play-with-go/preguide` is shortened to simply `preguide`):
+
+* `preguide.#Command` - run a sequence of commands, providing those steps inline with the step declaration
+* `preguide.#CommandFile` - run a sequence of commands, with the steps being sourced from a file
+* `preguide.#Upload` - upload a file to the remote session, providing the files contents inline with the step declaration
+* `preguide.#UploadFile` - upload a file to the remote session, with the file contents being sourced from a file
+
+Within a the markdown prose
+
+## Translations and scenarios
+
+TODO:
+
+Explain that:
+
+* a guide can vary by langauge (i.e. translated into a different language, potentially with different steps specific to
+  that language), and/or
+* a giude can vary by scenario. e.g. a guide is predominantly writtern for Go 1.15, but alternative language (and steps)
+  are provided for Go 1.14 where there are differences
+
+
+## Multiple remote sessions
+
+TODO:
+
+Explain that:
+
+* guides can be written to leverage multiple terminals, i.e. remote sessions. Particularly useful for client-server
+  interaction examples
+
+## Reference directives
+
+Consider the following commands:
+
+<!-- step: random_commands -->
+
+Notice how the step is declared in terms of a `Defs`-declared message. We can reference that message in the prose of a
+guide using a `ref` directive: `<!-- ref: random_message -->`.
+
+Similarly, we can use `outref` directives to refer to the result of executing the guide script. For example, here we
+reference the output from the `<!-- ref: go_env_gopath -->` command directly in our prose: `<!-- outref: go_env_gopath
+-->`.
+
+TODO:
+
+Explain that, as the guide author, you can include `ref` and `outref` directives to reference specific aspects of a
+guide.
+
+`ref` directives refer to `Defs` fields that are defined as part of the _input_ guide CUE package. They can be
+arbitrary string values. Those `Defs` fields are then typically used within step declarations for that guide. Using
+`ref` directives in this way ensures that parts of the guide prose and script stay consistent.
+
+`outref` directives refer to `Defs` fields that are defined as part of the _output_ guide CUE package. This allows
+the guide author to reference specific parts of the output

--- a/contributing/en.markdown
+++ b/contributing/en.markdown
@@ -1,0 +1,139 @@
+### Writing your first `play-with-go.dev` guide!
+
+This guide explains how to create your first `play-with-go.dev` guide using the `play-with-go` development environment.
+Guides are first developed locally, then pushed as pull requests to the
+[`play-with-go`](https://github.com/play-with-go/play-with-go) project.
+
+_This_ guide the entire local development process.  Creating a pull request and the review workflow is discussed
+elsewhere (TODO: create a wiki/document).
+
+### Prerequisites
+
+This guide uses the following commands:
+
+{{{ step "tool_versions" }}}
+
+### Getting started `play-with-go`
+
+Start by cloning the `play-with-go` project:
+
+{{{ step "clone_play_with_go" }}}
+
+{{{ step "create_file" }}}
+
+Create a branch for our changes:
+
+As you can see, we are using commit [`<!--def: playWithGoCommit -->`](https://github.com/play-with-go/play-with-go/tree/{{{ .playWithGoCommit }}})
+as a known starting point; you can omit this commit if you like which default to using `origin/main`
+
+TODO: make this a guide that demonstrates how to create a guide.
+
+## Terminology and Overall structure
+
+Explain:
+
+* how guides are the result of combinding the markdown prose with a CUE specification of the "steps" in that guide, i.e.
+  the commands the user will run
+* the directory structure currently used by play-with-go, and how this feeds into the Jekyll frontend
+* the concept of the input guide CUE package and the generated output (that can be augmented with guide author
+  declarations)
+* ...
+
+We use the following terminology:
+
+* the user - the end user who is reading and following the guide in a browser, executing the various steps via the PWD
+  console
+* guide author - the person who created the guide
+* `preguide` - is the authoring tool used by the guide author when writing a guide. `preguide` ensures that the steps in
+  a guide can be run and are reproducible
+* remote session - is used to refer to the container that is driving the container that is visualised via the frontend
+  terminal
+* define the terms input and output. Possibly distinguish between the markdown and script input, and markdown and
+  command result output. A diagram?
+
+## Presteps
+
+Presteps are declared by a guide author to run as each guide instance is launched. For example, for this guide we have a
+prestep that creates a unique user account and repository in the source control system that supports the
+`play-with-go.dev/userguides/...` modules. This therefore allows us to create a local `git` repository that uses the
+that remote repository:
+
+<!-- step: create_local_repo -->
+
+Let's add a readme file to explain what this repository is all about:
+
+<!-- step: add_readme -->
+
+Create our initial commit and push to the remote repository:
+
+<!-- step: create_initial_commit -->
+
+
+TODO:
+
+* make this a Go module for a library
+* then create a local Go module that uses the new library and pulls that through the proxy
+* explain that a guide can run multiple presteps, or none
+
+## Different types of step
+
+`preguide` defines two basic steps that a user can perform:
+
+* run a sequence of commands
+* uploading a file
+
+`preguide` exposes these to the guide author as four step types (the reference to the CUE package
+`github.com/play-with-go/preguide` is shortened to simply `preguide`):
+
+* `preguide.#Command` - run a sequence of commands, providing those steps inline with the step declaration
+* `preguide.#CommandFile` - run a sequence of commands, with the steps being sourced from a file
+* `preguide.#Upload` - upload a file to the remote session, providing the files contents inline with the step declaration
+* `preguide.#UploadFile` - upload a file to the remote session, with the file contents being sourced from a file
+
+Within a the markdown prose
+
+## Translations and scenarios
+
+TODO:
+
+Explain that:
+
+* a guide can vary by langauge (i.e. translated into a different language, potentially with different steps specific to
+  that language), and/or
+* a giude can vary by scenario. e.g. a guide is predominantly writtern for Go 1.15, but alternative language (and steps)
+  are provided for Go 1.14 where there are differences
+
+
+## Multiple remote sessions
+
+TODO:
+
+Explain that:
+
+* guides can be written to leverage multiple terminals, i.e. remote sessions. Particularly useful for client-server
+  interaction examples
+
+## Reference directives
+
+Consider the following commands:
+
+<!-- step: random_commands -->
+
+Notice how the step is declared in terms of a `Defs`-declared message. We can reference that message in the prose of a
+guide using a `ref` directive: `<!-- ref: random_message -->`.
+
+Similarly, we can use `outref` directives to refer to the result of executing the guide script. For example, here we
+reference the output from the `<!-- ref: go_env_gopath -->` command directly in our prose: `<!-- outref: go_env_gopath
+-->`.
+
+TODO:
+
+Explain that, as the guide author, you can include `ref` and `outref` directives to reference specific aspects of a
+guide.
+
+`ref` directives refer to `Defs` fields that are defined as part of the _input_ guide CUE package. They can be
+arbitrary string values. Those `Defs` fields are then typically used within step declarations for that guide. Using
+`ref` directives in this way ensures that parts of the guide prose and script stay consistent.
+
+`outref` directives refer to `Defs` fields that are defined as part of the _output_ guide CUE package. This allows
+the guide author to reference specific parts of the output

--- a/contributing/en_log.txt
+++ b/contributing/en_log.txt
@@ -1,0 +1,27 @@
+Terminals: [
+  {
+    "Name": "term1",
+    "Description": "The main terminal",
+    "Scenarios": {
+      "go115": {
+        "Image": "playwithgo/create-your-first-guide"
+      }
+    }
+  }
+]
+$ docker version -f {{.Server.Version}}
+19.03.12
+$ docker-compose version
+docker-compose version 1.26.2, build eefe0d31
+docker-py version: 4.2.2
+CPython version: 3.7.7
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+$ go version
+go version go1.15.1 linux/amd64
+$ mkcert -version
+v1.4.1
+$ git clone https://github.com/play-with-go/play-with-go
+Cloning into 'play-with-go'...
+$ cd play-with-go
+$ git checkout -b myfirstguide 206a134e21007d1970e92be68ed0a2451376208a
+Switched to a new branch 'myfirstguide'

--- a/contributing/go115_en_log.txt
+++ b/contributing/go115_en_log.txt
@@ -1,0 +1,18 @@
+$ docker version -f {{.Server.Version}}
+19.03.13
+$ docker-compose version
+docker-compose version 1.26.2, build eefe0d31
+docker-py version: 4.2.2
+CPython version: 3.7.7
+OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+$ go version
+go version go1.15.5 linux/amd64
+$ git clone -q https://github.com/play-with-go/play-with-go
+$ cd play-with-go
+$ git checkout simple_guide
+Branch 'simple_guide' set up to track remote branch 'simple_guide' from 'origin'.
+Switched to a new branch 'simple_guide'
+$ cat <<EOD > /home/gopher/play-with-go/blah.txt
+Blah
+
+EOD

--- a/contributing/guide.cue
+++ b/contributing/guide.cue
@@ -1,0 +1,57 @@
+package guide
+
+import (
+	"github.com/play-with-go/preguide"
+)
+
+Defs: {
+	_#commonDefs
+	playWithGoCommit: "simple_guide"
+	myfirstguide:     "2020-11-25-myfirstguide"
+}
+
+Delims: ["{{{", "}}}"]
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "playwithgo/create-your-first-guide"
+}
+
+Steps: tool_versions: preguide.#Command & {Source: """
+	docker version -f {{.Server.Version}}
+	docker-compose version
+	go version
+	"""}
+
+Steps: clone_play_with_go: preguide.#Command & {Source: """
+	\(Defs.git.clone) https://github.com/play-with-go/play-with-go
+	cd play-with-go
+	git checkout \(Defs.playWithGoCommit)
+	"""}
+// git checkout -b myfirstguide \(Defs.playWithGoCommit)
+
+// Steps: create_branch: preguide.#Command & {
+//  Source: """
+//  ./_scripts/dc.sh build
+//  ./_scripts/dc.sh up -d
+//  ./_scripts/generateGuides.sh
+//  """
+// }
+
+// Steps: start_guide: preguide.#Command & {
+//  Source: """
+//  mkdir guides/\(Defs.myfirstguide)
+//  """
+// }
+
+Steps: create_file: preguide.#Upload & {
+	Target: "/home/gopher/play-with-go/blah.txt"
+	Source: """
+		Blah
+
+		"""
+}

--- a/contributing/out/gen_out.cue
+++ b/contributing/out/gen_out.cue
@@ -1,0 +1,123 @@
+package out
+
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "playwithgo/create-your-first-guide"
+		}
+	}
+}]
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: ["playwithgo_pwg"]
+Env: []
+FilenameComment: false
+Steps: {
+	tool_versions: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "tool_versions"
+		Order:           0
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "docker version -f {{.Server.Version}}"
+			ExitCode: 0
+			Output: """
+				19.03.13
+
+				"""
+			ComparisonOutput: """
+				19.03.13
+
+				"""
+		}, {
+			Negated:  false
+			CmdStr:   "docker-compose version"
+			ExitCode: 0
+			Output: """
+				docker-compose version 1.26.2, build eefe0d31
+				docker-py version: 4.2.2
+				CPython version: 3.7.7
+				OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+
+				"""
+			ComparisonOutput: """
+				docker-compose version 1.26.2, build eefe0d31
+				docker-py version: 4.2.2
+				CPython version: 3.7.7
+				OpenSSL version: OpenSSL 1.1.0l  10 Sep 2019
+
+				"""
+		}, {
+			Negated:  false
+			CmdStr:   "go version"
+			ExitCode: 0
+			Output: """
+				go version go1.15.5 linux/amd64
+
+				"""
+			ComparisonOutput: """
+				go version go1.15.5 linux/amd64
+
+				"""
+		}]
+	}
+	clone_play_with_go: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "clone_play_with_go"
+		Order:           1
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "git clone -q https://github.com/play-with-go/play-with-go"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "cd play-with-go"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "git checkout simple_guide"
+			ExitCode: 0
+			Output: """
+				Branch 'simple_guide' set up to track remote branch 'simple_guide' from 'origin'.
+				Switched to a new branch 'simple_guide'
+
+				"""
+			ComparisonOutput: """
+				Branch 'simple_guide' set up to track remote branch 'simple_guide' from 'origin'.
+				Switched to a new branch 'simple_guide'
+
+				"""
+		}]
+	}
+	create_file: {
+		StepType: 2
+		Name:     "create_file"
+		Order:    2
+		Terminal: "term1"
+		Language: "txt"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			Blah
+
+			"""
+		Target: "/home/gopher/play-with-go/blah.txt"
+	}
+}
+Hash: "d5c8d27e5545459eefb2ead4b3312b50e539e224d3f51d3fcd288432746f1da0"
+Delims: ["{{{", "}}}"]

--- a/guide.cue
+++ b/guide.cue
@@ -57,6 +57,7 @@ _#commonDefs: {
 		tag:      "git tag"
 		revparse: "git rev-parse"
 		branch:   "git branch"
+		clone:    "git clone -q"
 	}
 	proxygolangorg: {
 		waitforcache: "1m" // value passed to Unix sleep

--- a/guides/2020-10-07-intro-to-play-with-go-dev/en.markdown
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/en.markdown
@@ -6,6 +6,8 @@ difficulty: Beginner
 category: Start here
 ---
 
+Hello &#123;&#123; .world &#125;&#125;
+
 [`play-with-go.dev`](https://play-with-go.dev/) is a series of interactive browser-based guides that lead you on a tour
 of the [Go command](https://golang.org/cmd/go/) and [Go modules](https://golang.org/ref/mod).
 


### PR DESCRIPTION
guides: create a simple guide as a demo of how to do it!

guides/2020-08-26-simple-guide will remain as an example of the various
features of preguide.

A guide comprises two parts: the prose and a script. The prose is
written as markdown and may include directives that reference parts of
the script. The script is written as CUE, and ultimately specifies a
number of steps to run. Each step may either be a command or an upload
of a file content.

Guides are created in the guides directory. Each guide lives in a
directory of its own. The naming convention is as follows:

    guides/2020-08-26-simple-guide

The date is used here to specify the date of creation. This date acts as
an ordering relative to the date of other guides. The "simple-guide"
suffix is what appears in the URL path when served via Jekyll.

The prose for a guide is specified in language-specific files. For
example, we write the English variant of a guide in:

    guides/2020-08-26-simple-guide/en.markdown

The script for a guide is written in .cue files in the guide directory.
The script can be split across any number of .cue files, however all
files must belong to the guide package.

The ordering of steps is defined by the source position of a step's
first declaration in a lexicographic ordering of the CUE package's
files.

See the example guide itself for examples of how reference and out
reference directives can also be used.
