### PR TITLE
deps: upgrade to latest PWD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,8 @@ require (
 	cuelang.org/go v0.2.2
 	github.com/kr/pretty v0.2.0
 	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
-	github.com/play-with-docker/play-with-docker v0.0.2-0.20200622012609-cf50d344b2d8
+	github.com/play-with-docker/play-with-docker v0.0.3-0.20200904130329-2d1515d12fb0
 	github.com/play-with-go/gitea v0.0.0-20200903101414-d298acd78a27
 	github.com/play-with-go/preguide v0.0.0-20200903100314-03754f51d880
 	golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a
 )
-
-replace github.com/play-with-docker/play-with-docker => github.com/myitcvforks/play-with-docker v0.0.2-0.20200827184138-85ca8fc6c99b

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,6 @@ github.com/muesli/smartcrop v0.3.0/go.mod h1:i2fCI/UorTfgEpPPLWiFBv4pye+YAG78Rwc
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f h1:pqpnXNqsaw1JN83pfyLCUDZqGn0b+nJ1uYD1/R9aURg=
 github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f/go.mod h1:8FDe0/d1OM678ejROLq0oqBo9YsnReTK7jcnJ3a88Ck=
-github.com/myitcvforks/play-with-docker v0.0.2-0.20200827184138-85ca8fc6c99b h1:VUjWnxIKh+BBP7uO61RHybM0K6K0Jsm17GUMhL59ttA=
-github.com/myitcvforks/play-with-docker v0.0.2-0.20200827184138-85ca8fc6c99b/go.mod h1:qXpTLW1J5QAuPGtj7NPB9NXMaWuL/NHnLtrboDZe4no=
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
@@ -396,6 +394,8 @@ github.com/pkg/diff v0.0.0-20190930165518-531926345625/go.mod h1:kFj35MyHn14a6pI
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/play-with-docker/play-with-docker v0.0.3-0.20200904130329-2d1515d12fb0 h1:DHKc4kBXc9f7ObUCbkoPOuGAiYJDHEbCSWSKN7iBMcE=
+github.com/play-with-docker/play-with-docker v0.0.3-0.20200904130329-2d1515d12fb0/go.mod h1:qXpTLW1J5QAuPGtj7NPB9NXMaWuL/NHnLtrboDZe4no=
 github.com/play-with-go/gitea v0.0.0-20200903101414-d298acd78a27 h1:MIMr4/MeenvDtZ7j8lvjNkUIkDF2D96x2qsYFd2VLxs=
 github.com/play-with-go/gitea v0.0.0-20200903101414-d298acd78a27/go.mod h1:uQ67ahxOjvzzW4IdyUvk+LYEjAd18S6aDHo6AwGCKvA=
 github.com/play-with-go/preguide v0.0.0-20200903100314-03754f51d880 h1:AfRrkFpPeNlSCaOOiaqQkrMKe1i+uKEkJd1zm5RvzGg=


### PR DESCRIPTION
This means we can now move away from the fork which referenced a number
of PRs on which PWG depended.