### PR TITLE
guides: use {{{ }}} delims by default

### DIFF
--- a/_posts/2020-09-01-basic-go-modules-example.markdown
+++ b/_posts/2020-09-01-basic-go-modules-example.markdown
@@ -19,17 +19,17 @@ $ mkdir /home/gopher/mod1
 $ cd /home/gopher/mod1
 $ git init
 Initialized empty Git repository in /home/gopher/mod1/.git/
-$ git remote add origin https://play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}.git
-$ go mod init play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}
-go: creating new go.mod: module play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}
+$ git remote add origin https://play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}.git
+$ go mod init play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}
+go: creating new go.mod: module play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}
 ```
-{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL21vZDEKY2QgL2hvbWUvZ29waGVyL21vZDEKZ2l0IGluaXQKZ2l0IHJlbW90ZSBhZGQgb3JpZ2luIGh0dHBzOi8vcGxheS13aXRoLWdvLmRldi91c2VyZ3VpZGVzL3t7LlJFUE8xfX0uZ2l0CmdvIG1vZCBpbml0IHBsYXktd2l0aC1nby5kZXYvdXNlcmd1aWRlcy97ey5SRVBPMX19Cg=="}
+{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL21vZDEKY2QgL2hvbWUvZ29waGVyL21vZDEKZ2l0IGluaXQKZ2l0IHJlbW90ZSBhZGQgb3JpZ2luIGh0dHBzOi8vcGxheS13aXRoLWdvLmRldi91c2VyZ3VpZGVzL3t7ey5SRVBPMX19fS5naXQKZ28gbW9kIGluaXQgcGxheS13aXRoLWdvLmRldi91c2VyZ3VpZGVzL3t7ey5SRVBPMX19fQo="}
 
 Write a readme:
 
 ```.term1
 cat <<'EOD' > /home/gopher/mod1/README.md
-## `play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}`
+## `play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}`
 EOD
 ```
 
@@ -60,7 +60,7 @@ $ git commit -m "Initial commit"
 $ git push -u origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
-To https://play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}.git
+To https://play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}.git
  * [new branch]      main -> main
 Branch 'main' set up to track remote branch 'main' from 'origin'.
 ```
@@ -73,12 +73,12 @@ $ mkdir /home/gopher/mod2
 $ cd /home/gopher/mod2
 $ go mod init mod.com
 go: creating new go.mod: module mod.com
-$ go get play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}
-go: downloading play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %} v0.0.0-20060102150405-abcde12345
-go: play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %} upgrade => v0.0.0-20060102150405-abcde12345
-$ go run play-with-go.dev/userguides/{% raw %}{{.REPO1}}{% endraw %}
+$ go get play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}
+go: downloading play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %} v0.0.0-20060102150405-abcde12345
+go: play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %} upgrade => v0.0.0-20060102150405-abcde12345
+$ go run play-with-go.dev/userguides/{% raw %}{{{.REPO1}}}{% endraw %}
 Hello, world!
 ```
-{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL21vZDIKY2QgL2hvbWUvZ29waGVyL21vZDIKZ28gbW9kIGluaXQgbW9kLmNvbQpnbyBnZXQgcGxheS13aXRoLWdvLmRldi91c2VyZ3VpZGVzL3t7LlJFUE8xfX0KZ28gcnVuIHBsYXktd2l0aC1nby5kZXYvdXNlcmd1aWRlcy97ey5SRVBPMX19Cg=="}
+{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL21vZDIKY2QgL2hvbWUvZ29waGVyL21vZDIKZ28gbW9kIGluaXQgbW9kLmNvbQpnbyBnZXQgcGxheS13aXRoLWdvLmRldi91c2VyZ3VpZGVzL3t7ey5SRVBPMX19fQpnbyBydW4gcGxheS13aXRoLWdvLmRldi91c2VyZ3VpZGVzL3t7ey5SRVBPMX19fQo="}
 
 <script>let pageGuide="2020-09-01-basic-go-modules-example"; let pageLanguage="en"; let pageScenario="go115";</script>

--- a/guides/2020-09-01-basic-go-modules-example/en_log.txt
+++ b/guides/2020-09-01-basic-go-modules-example/en_log.txt
@@ -33,11 +33,11 @@ $ mkdir /home/gopher/mod1
 $ cd /home/gopher/mod1
 $ git init
 Initialized empty Git repository in /home/gopher/mod1/.git/
-$ git remote add origin https://play-with-go.dev/userguides/{{.REPO1}}.git
-$ go mod init play-with-go.dev/userguides/{{.REPO1}}
-go: creating new go.mod: module play-with-go.dev/userguides/{{.REPO1}}
+$ git remote add origin https://play-with-go.dev/userguides/{{{.REPO1}}}.git
+$ go mod init play-with-go.dev/userguides/{{{.REPO1}}}
+go: creating new go.mod: module play-with-go.dev/userguides/{{{.REPO1}}}
 $ cat <<EOD > /home/gopher/mod1/README.md
-## `play-with-go.dev/userguides/{{.REPO1}}`
+## `play-with-go.dev/userguides/{{{.REPO1}}}`
 EOD
 $ cat <<EOD > /home/gopher/mod1/main.go
 package main
@@ -58,15 +58,15 @@ $ git commit -m "Initial commit"
 $ git push -u origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
-To https://play-with-go.dev/userguides/{{.REPO1}}.git
+To https://play-with-go.dev/userguides/{{{.REPO1}}}.git
  * [new branch]      main -> main
 Branch 'main' set up to track remote branch 'main' from 'origin'.
 $ mkdir /home/gopher/mod2
 $ cd /home/gopher/mod2
 $ go mod init mod.com
 go: creating new go.mod: module mod.com
-$ go get play-with-go.dev/userguides/{{.REPO1}}
-go: downloading play-with-go.dev/userguides/{{.REPO1}} v0.0.0-20060102150405-abcde12345
-go: play-with-go.dev/userguides/{{.REPO1}} upgrade => v0.0.0-20060102150405-abcde12345
-$ go run play-with-go.dev/userguides/{{.REPO1}}
+$ go get play-with-go.dev/userguides/{{{.REPO1}}}
+go: downloading play-with-go.dev/userguides/{{{.REPO1}}} v0.0.0-20060102150405-abcde12345
+go: play-with-go.dev/userguides/{{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcde12345
+$ go run play-with-go.dev/userguides/{{{.REPO1}}}
 Hello, world!

--- a/guides/2020-09-01-basic-go-modules-example/guide.cue
+++ b/guides/2020-09-01-basic-go-modules-example/guide.cue
@@ -31,12 +31,12 @@ Steps: create_module: en: preguide.#Command & {Source: """
 mkdir \(Defs.mod1)
 cd \(Defs.mod1)
 git init
-git remote add origin https://play-with-go.dev/userguides/{{.REPO1}}.git
-go mod init play-with-go.dev/userguides/{{.REPO1}}
+git remote add origin https://play-with-go.dev/userguides/{{{.REPO1}}}.git
+go mod init play-with-go.dev/userguides/{{{.REPO1}}}
 """}
 
 Steps: create_readme: en: preguide.#Upload & {Target: Defs.mod1 + "/README.md", Source: """
-## `play-with-go.dev/userguides/{{.REPO1}}`
+## `play-with-go.dev/userguides/{{{.REPO1}}}`
 """}
 
 Steps: create_main: en: preguide.#Upload & {Target: Defs.mod1 + "/main.go", Source: """
@@ -59,6 +59,6 @@ Steps: use_module: en: preguide.#Command & {Source: """
 mkdir \(Defs.mod2)
 cd \(Defs.mod2)
 go mod init mod.com
-go get play-with-go.dev/userguides/{{.REPO1}}
-go run play-with-go.dev/userguides/{{.REPO1}}
+go get play-with-go.dev/userguides/{{{.REPO1}}}
+go run play-with-go.dev/userguides/{{{.REPO1}}}
 """}

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -127,7 +127,7 @@ package out
         """
 		Variables: ["GITEA_USERNAME", "GITEA_PASSWORD", "REPO1"]
 	}]
-	Delims: ["{{", "}}"]
+	Delims: ["{{{", "}}}"]
 	Terminals: [{
 		Name:        "term1"
 		Description: "The main terminal"
@@ -165,15 +165,15 @@ package out
         """
 					}, {
 						Negated:  false
-						CmdStr:   "git remote add origin https://play-with-go.dev/userguides/{{.REPO1}}.git"
+						CmdStr:   "git remote add origin https://play-with-go.dev/userguides/{{{.REPO1}}}.git"
 						ExitCode: 0
 						Output:   ""
 					}, {
 						Negated:  false
-						CmdStr:   "go mod init play-with-go.dev/userguides/{{.REPO1}}"
+						CmdStr:   "go mod init play-with-go.dev/userguides/{{{.REPO1}}}"
 						ExitCode: 0
 						Output: """
-        go: creating new go.mod: module play-with-go.dev/userguides/{{.REPO1}}
+        go: creating new go.mod: module play-with-go.dev/userguides/{{{.REPO1}}}
         
         """
 					}]
@@ -187,7 +187,7 @@ package out
 					Renderer: {
 						RendererType: 1
 					}
-					Source: "## `play-with-go.dev/userguides/{{.REPO1}}`"
+					Source: "## `play-with-go.dev/userguides/{{{.REPO1}}}`"
 					Order:  1
 				}
 				create_main: {
@@ -239,7 +239,7 @@ package out
 						Output: """
         remote: . Processing 1 references        
         remote: Processed 1 references in total        
-        To https://play-with-go.dev/userguides/{{.REPO1}}.git
+        To https://play-with-go.dev/userguides/{{{.REPO1}}}.git
          * [new branch]      main -> main
         Branch 'main' set up to track remote branch 'main' from 'origin'.
         
@@ -271,16 +271,16 @@ package out
         """
 					}, {
 						Negated:  false
-						CmdStr:   "go get play-with-go.dev/userguides/{{.REPO1}}"
+						CmdStr:   "go get play-with-go.dev/userguides/{{{.REPO1}}}"
 						ExitCode: 0
 						Output: """
-        go: downloading play-with-go.dev/userguides/{{.REPO1}} v0.0.0-20060102150405-abcde12345
-        go: play-with-go.dev/userguides/{{.REPO1}} upgrade => v0.0.0-20060102150405-abcde12345
+        go: downloading play-with-go.dev/userguides/{{{.REPO1}}} v0.0.0-20060102150405-abcde12345
+        go: play-with-go.dev/userguides/{{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcde12345
         
         """
 					}, {
 						Negated:  false
-						CmdStr:   "go run play-with-go.dev/userguides/{{.REPO1}}"
+						CmdStr:   "go run play-with-go.dev/userguides/{{{.REPO1}}}"
 						ExitCode: 0
 						Output: """
         Hello, world!
@@ -289,7 +289,7 @@ package out
 					}]
 				}
 			}
-			Hash: "1dd15a2b13fc289d88730783c8944bd35d55e1bf15fb400ad319066db3f347d2"
+			Hash: "cad86716022189e64828c37c98c9488ac787e0d4bddfb6d415d841e087831024"
 		}
 	}
 }

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -17,7 +17,7 @@ package guides
 			}]
 		}
 	}]
-	Delims: ["{{", "}}"]
+	Delims: ["{{{", "}}}"]
 	Terminals: [{
 		Name:        "term1"
 		Description: "The main terminal"

--- a/guides/guide.cue
+++ b/guides/guide.cue
@@ -4,4 +4,6 @@ Env: *["PLAYWITHGO_ROOTCA"] | [...string]
 
 Networks: *["playwithgo_gitea"] | [...string]
 
+Delims: ["{{{", "}}}"]
+
 #go115LatestImage: "playwithgo/go1.15.1@sha256:009b09b0b12874cb1dd362bc2471e39d430f6c2c7cac47dc9db2ab7a4290e59b"


### PR DESCRIPTION
In order that we don't have to special case guides that use go list with
{{  }}