### PR TITLE
Explicitly set CGO_ENABLED=0

### DIFF
--- a/_scripts/dc.sh
+++ b/_scripts/dc.sh
@@ -16,7 +16,7 @@ fi
 
 bin="$( command cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/../.bin"
 
-GOBIN=$bin go install github.com/play-with-docker/play-with-docker github.com/play-with-docker/play-with-docker/router/l2 \
+CGO_ENABLED=0 GOBIN=$bin go install github.com/play-with-docker/play-with-docker github.com/play-with-docker/play-with-docker/router/l2 \
 	github.com/play-with-go/gitea/cmd/gitea github.com/play-with-go/play-with-go/cmd/controller
 
 export GOMODCACHE="$(go env GOPATH | cut -f 1 -d :)"/pkg/mod


### PR DESCRIPTION
This allows us to musl libc docker images when running on Linux