### PR TITLE
js: decode data-upload-path when "fixing" attributes of code blocks

### DIFF
--- a/docs/js/post-layout.js
+++ b/docs/js/post-layout.js
@@ -41,13 +41,16 @@ guideRequest.onload = function() {
 		replacements.push([guideDetails.Delims[0]+"."+parts[0]+guideDetails.Delims[1], parts[1]]);
 	}
 	replaceInText(document.querySelector("article"), replacements);
-	for (let attr of ["data-upload-src", "data-command-src"]) {
+	for (let attr of ["data-upload-src", "data-command-src", "data-upload-path"]) {
 		document.querySelectorAll("["+attr+"]").forEach(function(node) {
 			let v = atob(node.getAttribute(attr));
 			for (let r of replacements) {
 				v = replaceAll(v, r[0], r[1]);
 			}
-			node.setAttribute(attr, btoa(v));
+			if (attr != "data-upload-path") {
+				v = btoa(v);
+			}
+			node.setAttribute(attr, v);
 		});
 	}
 	pwd.newSession(guideDetails.Terminals, { baseUrl: "https://api.play-with-go.dev", oauthProvider: 'google', Networks: guideDetails.Networks, Envs: guideDetails.Env });

--- a/js/post-layout.js
+++ b/js/post-layout.js
@@ -43,13 +43,16 @@ guideRequest.onload = function() {
 		replacements.push([guideDetails.Delims[0]+"."+parts[0]+guideDetails.Delims[1], parts[1]]);
 	}
 	replaceInText(document.querySelector("article"), replacements);
-	for (let attr of ["data-upload-src", "data-command-src"]) {
+	for (let attr of ["data-upload-src", "data-command-src", "data-upload-path"]) {
 		document.querySelectorAll("["+attr+"]").forEach(function(node) {
 			let v = atob(node.getAttribute(attr));
 			for (let r of replacements) {
 				v = replaceAll(v, r[0], r[1]);
 			}
-			node.setAttribute(attr, btoa(v));
+			if (attr != "data-upload-path") {
+				v = btoa(v);
+			}
+			node.setAttribute(attr, v);
 		});
 	}
 	pwd.newSession(guideDetails.Terminals, { baseUrl: "{{site.pwdurl}}", oauthProvider: 'google', Networks: guideDetails.Networks, Envs: guideDetails.Env });


### PR DESCRIPTION
Only applies to non-compat mode, but making this change now so we don't
forget to later.