### PR TITLE
docker: fix site generate

### DIFF
--- a/docker/site/Dockerfile
+++ b/docker/site/Dockerfile
@@ -2,3 +2,7 @@
 FROM jekyll/jekyll@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34
 
 RUN gem install jekyll-toc
+
+# Overwrite the entrypoint and jekyll with more sensible versions
+COPY docker/site/entrypoint /usr/jekyll/bin/entrypoint
+COPY docker/site/jekyll /usr/jekyll/bin/jekyll

--- a/docker/site/entrypoint
+++ b/docker/site/entrypoint
@@ -1,0 +1,35 @@
+#!/bin/bash
+[ "$DEBUG" = "true" ] && set -x
+set -e
+
+# If the user does not supply values, assume the build defaults
+: ${JEKYLL_UID:=$(id -u jekyll)}
+: ${JEKYLL_GID:=$(id -g jekyll)}
+
+export JEKYLL_UID
+export JEKYLL_GID
+
+# At this point JEKYLL_UID and JEKYLL_GID represent the UID and GID
+# we should use. There is no point updating the jekyll user and group
+# because the UID and GID might conflict with other users or groups
+
+# --
+# Users can customize our UID's to fit their own so that
+#   we don't have to chown constantly.  Well it's not like
+#   we do so much of it (anymore) it's slow, but we do
+#   change permissions which can result in some bad
+#   behavior on OS X.
+# --
+# if [ "$JEKYLL_UID" != "0" ] && [ "$JEKYLL_UID" != "$(id -u jekyll)" ]; then
+#   usermod  -u $JEKYLL_UID jekyll
+#   groupmod -g $JEKYLL_GID jekyll
+#   chown_args=""
+
+#   [ "$FULL_CHOWN" ] && chown_args="-R"
+#   for d in "$JEKYLL_DATA_DIR" "$JEKYLL_VAR_DIR"; do
+#     chown $chown_args $JEKYLL_UID:$JEKYLL_GID "$d"
+#   done
+# fi
+
+# --
+exec "$@"

--- a/docker/site/jekyll
+++ b/docker/site/jekyll
@@ -1,0 +1,37 @@
+#!/bin/sh
+[ "$DEBUG" = "true" ] && set -x
+set -e
+
+args=$(default-args $@)
+
+# --
+# The assumption here is that if we aren't ID 0 then
+#   something we wrapped, recalled us, so we need to ship
+#   them to the right spot.  This can happen in one
+#   scenario (when you do `jekyll new`.)
+# --
+if [ "$(id -u)" != "0" ]; then
+  exec $BUNDLE_BIN/jekyll "$@"
+fi
+
+# --
+[ -d ".cache" ] && chown -R $JEKYLL_UID:$JEKYLL_GID .cache
+[ -d ".jekyll-cache" ] && chown -R $JEKYLL_UID:$JEKYLL_GID .jekyll-cache
+[ -d ".sass-cache" ] && chown -R $JEKYLL_UID:$JEKYLL_GID .sass-cache
+[ -d "_site" ] && chown -R $JEKYLL_UID:$JEKYLL_GID _site
+
+# --
+# Install if the user has a Gemfile.
+# Install if we are also connecteds.
+# --
+if [ -f "Gemfile" ] && connected; then
+  bundle install
+fi
+
+echo "$(ruby --version)"
+
+sup_args=""
+exe=$BUNDLE_BIN/jekyll
+[ "$JEKYLL_DOCKER_TAG" = "pages" ] && sup_args="-r github-pages"
+[ -x "$exe" ] && exec su-exec $JEKYLL_UID:$JEKYLL_GID bundle exec ruby $sup_args $exe $args
+su-exec $JEKYLL_UID:$JEKYLL_GID ruby $sup_args $GEM_BIN/jekyll $args


### PR DESCRIPTION
The default jekyll image does some werid things when passed a JEKYLL_UID
and JEKYLL_GID value. It tries to modify the existing, build-created,
jekyll user in the container. However, this will not work if the passed
values happen to conflict with an existing user/group.

Instead, the entrypoint should define that JEKYLL_UID and JEKYLL_GID
represent the UID and GID as which the caller wants to run everything.
The jekyll user is really irrelevant in all of this.

Hence, we now provide a custom entrypoint and jekyll wrapper that
drives everything off JEKYLL_UID and JEKYLL_GID