### PR TITLE
guides: improve intro to PWG with details of gitea repos

### DIFF
--- a/_posts/2020-10-07-intro-to-play-with-go-dev.markdown
+++ b/_posts/2020-10-07-intro-to-play-with-go-dev.markdown
@@ -93,8 +93,16 @@ $ pwd
 ` user.
 
 Some guides need you to publish code to a remote source code repository. For such guides, a unique remote repository is
-automatically created against the https://gopher.live [`gitea`](https://gitea.io) instance. The URL of the repository will be
-made clear in the guide; authentication will be handled automatically.
+automatically created against the https://gopher.live [`gitea`](https://gitea.io) instance. The URL of the repository
+will be made clear in the guide; authentication will be handled automatically. For example, if we are creating a module
+called `hello`, the guide will automatically create a module path for us, like `gopher.live/{% raw %}{{{.REPO1}}}{% endraw %}`. The first part
+of this module path looks familiar: `gopher.live/hello`. It is followed by a random suffix that makes it unique to you.
+The remote version control system URL corresponding to this module path is `https://gopher.live/{% raw %}{{{.REPO1}}}{% endraw %}.git`:
+
+```.term1
+$ git ls-remote https://gopher.live/{% raw %}{{{.REPO1}}}{% endraw %}.git
+```
+{:data-command-src="Z2l0IGxzLXJlbW90ZSBodHRwczovL2dvcGhlci5saXZlL3t7ey5SRVBPMX19fS5naXQK"}
 
 
 ### I'm lost, help!

--- a/guides/2020-10-07-intro-to-play-with-go-dev/en.markdown
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/en.markdown
@@ -56,8 +56,13 @@ directory unless indicated otherwise:
 `<!--outref: wd-->` is referred to as the home directory of the `<!--outref: user-->` user.
 
 Some guides need you to publish code to a remote source code repository. For such guides, a unique remote repository is
-automatically created against the https://gopher.live [`gitea`](https://gitea.io) instance. The URL of the repository will be
-made clear in the guide; authentication will be handled automatically.
+automatically created against the https://gopher.live [`gitea`](https://gitea.io) instance. The URL of the repository
+will be made clear in the guide; authentication will be handled automatically. For example, if we are creating a module
+called `hello`, the guide will automatically create a module path for us, like `<!--ref:fullmodpath-->`. The first part
+of this module path looks familiar: `<!--ref:modpath-->`. It is followed by a random suffix that makes it unique to you.
+The remote version control system URL corresponding to this module path is `<!--ref: vcsurl -->`:
+
+<!--step: gitlsremote-->
 
 
 ### I'm lost, help!

--- a/guides/2020-10-07-intro-to-play-with-go-dev/en_log.txt
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/en_log.txt
@@ -16,7 +16,7 @@ Presteps: [
     "Args": {
       "Repos": [
         {
-          "Pattern": "mod1*",
+          "Pattern": "hello*",
           "Var": "REPO1"
         }
       ]
@@ -60,3 +60,6 @@ $ whoami
 gopher
 $ pwd
 /home/gopher
+$ echo gopher.live/{{{.REPO1}}}
+gopher.live/{{{.REPO1}}}
+$ git ls-remote https://gopher.live/{{{.REPO1}}}.git

--- a/guides/2020-10-07-intro-to-play-with-go-dev/guide.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/guide.cue
@@ -1,18 +1,23 @@
 package guide
 
 import (
+
 	"github.com/play-with-go/preguide"
 	"github.com/play-with-go/gitea"
 )
 
 Defs: {
-	readmetxt: "/home/gopher/readme.txt"
+	modname:     "hello"
+	modpath:     "gopher.live/\(modname)"
+	fullmodpath: "gopher.live/{{{.REPO1}}}"
+	vcsurl:      "https://gopher.live/{{{.REPO1}}}.git"
+	readmetxt:   "/home/gopher/readme.txt"
 }
 
 Presteps: [gitea.#PrestepNewUser & {
 	Args: {
 		Repos: [
-			{Var: "REPO1", Pattern: "mod1*"},
+			{Var: "REPO1", Pattern: Defs.modname + "*"},
 		]
 	}
 }]
@@ -74,5 +79,18 @@ Steps: whoami: en: preguide.#Command & {
 	Source: """
 		whoami
 		pwd
+		"""
+}
+
+Steps: echomodpath: en: preguide.#Command & {
+	Source: """
+		echo \(Defs.fullmodpath)
+		"""
+}
+
+Steps: gitlsremote: en: preguide.#Command & {
+	Source: """
+		git ls-remote \(Defs.vcsurl)
+		# no output because we have not committed anything
 		"""
 }

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -96,7 +96,7 @@ Presteps: [{
 	Args: {
 		Repos: [{
 			Var:     "REPO1"
-			Pattern: "mod1*"
+			Pattern: "hello*"
 		}]
 	}
 	Package: "github.com/play-with-go/gitea"
@@ -119,8 +119,37 @@ Networks: ["playwithgo_pwg"]
 Env: []
 Langs: {
 	en: {
-		Hash: "de8d2ab259d3564bdf04b0f0cfeacb2291ee6be56e1667e70b83b1361d8090e5"
+		Hash: "5e4d1dd73c539e38a1edb530d18b436b85d6eb094c72276133b686a050ae8509"
 		Steps: {
+			gitlsremote: {
+				Stmts: [{
+					TrimmedOutput: ""
+					Output:        ""
+					ExitCode:      0
+					CmdStr:        "git ls-remote https://gopher.live/{{{.REPO1}}}.git"
+					Negated:       false
+				}]
+				Order:    7
+				Terminal: "term1"
+				StepType: 1
+				Name:     "gitlsremote"
+			}
+			echomodpath: {
+				Stmts: [{
+					TrimmedOutput: "gopher.live/{{{.REPO1}}}"
+					Output: """
+						gopher.live/{{{.REPO1}}}
+
+						"""
+					ExitCode: 0
+					CmdStr:   "echo gopher.live/{{{.REPO1}}}"
+					Negated:  false
+				}]
+				Order:    6
+				Terminal: "term1"
+				StepType: 1
+				Name:     "echomodpath"
+			}
 			whoami: {
 				Stmts: [{
 					TrimmedOutput: "gopher"

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -35,7 +35,7 @@ package guides
 		Path:    "/newuser"
 		Args: {
 			Repos: [{
-				Pattern: "mod1*"
+				Pattern: "hello*"
 				Var:     "REPO1"
 			}]
 		}


### PR DESCRIPTION
Gives details on how guides are auto-initialised with a module path,
that also doubles as the remote VCS