### PR TITLE
Add cue files to controller image

### DIFF
--- a/cmd/controller/controller.go
+++ b/cmd/controller/controller.go
@@ -65,7 +65,7 @@ func (r *runner) mainerr() (err error) {
 			reqOrigin := req.Header.Get("Origin")
 			var set bool
 			for _, o := range r.fOrigins {
-				if o == reqOrigin {
+				if !set && o == reqOrigin {
 					resp.Header().Set("Access-Control-Allow-Origin", o)
 					set = true
 				}

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -19,5 +19,8 @@ RUN mkdir /runbin
 
 COPY --from=stage1 /go/cmd/controller/controller /runbin
 COPY ./docker/controller/playwithgo-entrypoint.sh /playwithgo-entrypoint.sh
+COPY ./prestep_conf.cue /start/
+COPY ./guides /start/
+COPY ./cue.mod /start/
 
 ENTRYPOINT ["/playwithgo-entrypoint.sh"]


### PR DESCRIPTION
This allows this image to be used in production. While used locally, the
files can/will be override by any possible volume mounts.

@myitcv I had to do this to deploy the controller image in prod since it was missing this files. Not sure If this is the proper way of doing it, but it works until we find a better way to deploy this. 

