### PR TITLE
guides: add InformationOnly steps for private modules guide

### DIFF
--- a/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
+++ b/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
@@ -177,8 +177,8 @@ Add a dependency on the `public` module:
 
 ```.term1
 $ go get {% raw %}{{{.PUBLIC}}}{% endraw %}
-go: downloading {% raw %}{{{.PUBLIC}}}{% endraw %} v0.0.0-20201112145351-6c967f8a533a
-go: {% raw %}{{{.PUBLIC}}}{% endraw %} upgrade => v0.0.0-20201112145351-6c967f8a533a
+go: downloading {% raw %}{{{.PUBLIC}}}{% endraw %} v0.0.0-20060102150405-abcedf12345
+go: {% raw %}{{{.PUBLIC}}}{% endraw %} upgrade => v0.0.0-20060102150405-abcedf12345
 ```
 {:data-command-src="Z28gZ2V0IHt7ey5QVUJMSUN9fX0K"}
 
@@ -190,7 +190,7 @@ Try to add a dependency on the `private` module:
 $ go get {% raw %}{{{.PRIVATE}}}{% endraw %}
 go get {% raw %}{{{.PRIVATE}}}{% endraw %}: module {% raw %}{{{.PRIVATE}}}{% endraw %}: reading https://proxy.golang.org/{% raw %}{{{.PRIVATE}}}{% endraw %}/@v/list: 410 Gone
 	server response:
-	not found: module {% raw %}{{{.PRIVATE}}}{% endraw %}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+	not found: module {% raw %}{{{.PRIVATE}}}{% endraw %}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 	Confirm the import path was entered correctly.
 	If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
@@ -210,10 +210,10 @@ And try once again to add a dependency on the `private` module:
 
 ```.term1
 $ go get {% raw %}{{{.PRIVATE}}}{% endraw %}
-go: downloading {% raw %}{{{.PRIVATE}}}{% endraw %} v0.0.0-20201112145352-806167d7acb5
-go get {% raw %}{{{.PRIVATE}}}{% endraw %}: {% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20201112145352-806167d7acb5: verifying module: {% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20201112145352-806167d7acb5: reading https://sum.golang.org/lookup/{% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20201112145352-806167d7acb5: 410 Gone
+go: downloading {% raw %}{{{.PRIVATE}}}{% endraw %} v0.0.0-20060102150405-abcedf12345
+go get {% raw %}{{{.PRIVATE}}}{% endraw %}: {% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20060102150405-abcedf12345: verifying module: {% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20060102150405-abcedf12345: 410 Gone
 	server response:
-	not found: {% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20201112145352-806167d7acb5: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+	not found: {% raw %}{{{.PRIVATE}}}{% endraw %}@v0.0.0-20060102150405-abcedf12345: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 ```
 {:data-command-src="Z28gZ2V0IHt7ey5QUklWQVRFfX19Cg=="}
@@ -242,8 +242,8 @@ succeeded):
 
 ```.term1
 $ go get {% raw %}{{{.PRIVATE}}}{% endraw %}
-go: downloading {% raw %}{{{.PRIVATE}}}{% endraw %} v0.0.0-20201112145352-806167d7acb5
-go: {% raw %}{{{.PRIVATE}}}{% endraw %} upgrade => v0.0.0-20201112145352-806167d7acb5
+go: downloading {% raw %}{{{.PRIVATE}}}{% endraw %} v0.0.0-20060102150405-abcedf12345
+go: {% raw %}{{{.PRIVATE}}}{% endraw %} upgrade => v0.0.0-20060102150405-abcedf12345
 ```
 {:data-command-src="Z28gZ2V0IHt7ey5QUklWQVRFfX19Cg=="}
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
 	github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e0
 	github.com/play-with-go/gitea v0.0.0-20201112105710-13a90a7e8526
-	github.com/play-with-go/preguide v0.0.2-0.20201112105706-464aa7e03365
+	github.com/play-with-go/preguide v0.0.2-0.20201112161106-44ae5cf00b09
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 )

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e
 github.com/play-with-go/gitea v0.0.0-20201112105710-13a90a7e8526 h1:0JH9kWYqa8pAgFfmX70kBO1IbtWPOdtUPxkfvFOB0Oo=
 github.com/play-with-go/gitea v0.0.0-20201112105710-13a90a7e8526/go.mod h1:mD4+vK9cH9dCfgegi5Z9+KSg79O9f0lOhg0sN8vve5M=
 github.com/play-with-go/preguide v0.0.2-0.20200929132054-e0f48a7f7b23/go.mod h1:jkhBBbIBioAzKiRo5Rr9r03tqglgUdPZAVIpBBw7aDU=
-github.com/play-with-go/preguide v0.0.2-0.20201112105706-464aa7e03365 h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=
-github.com/play-with-go/preguide v0.0.2-0.20201112105706-464aa7e03365/go.mod h1:GEaWl20b9zUa2BL8MQkOR7cMWD9PYlcs6lC0f2OiYnk=
+github.com/play-with-go/preguide v0.0.2-0.20201112161106-44ae5cf00b09 h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=
+github.com/play-with-go/preguide v0.0.2-0.20201112161106-44ae5cf00b09/go.mod h1:GEaWl20b9zUa2BL8MQkOR7cMWD9PYlcs6lC0f2OiYnk=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201112105706-464aa7e03365",
-		      "Sum": "h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=",
+		      "Version": "v0.0.2-0.20201112161106-44ae5cf00b09",
+		      "Sum": "h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=",
 		      "Replace": null
 		    },
 		    {
@@ -314,5 +314,5 @@ Steps: {
 		Name:            "create_module"
 	}
 }
-Hash: "0606cd3d88c5839ddcf127323d4d3ca7a61a597a121fcb595e2ad4f51f1e6963"
+Hash: "365fc8e80f35ea0414b5115024ee046fabe4f63557d14ac79ea3f89a62f1407b"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201112105706-464aa7e03365",
-		      "Sum": "h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=",
+		      "Version": "v0.0.2-0.20201112161106-44ae5cf00b09",
+		      "Sum": "h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=",
 		      "Replace": null
 		    },
 		    {
@@ -333,5 +333,5 @@ Steps: {
 		Name:            "whoami"
 	}
 }
-Hash: "a6234ad60ad895bd021252363096594f968f2e6463f000b84f8c61f14b5a536f"
+Hash: "d1542878eaae36f037eedaf989ade9df4eefb4518c97dd313096c0db5cbbb0a8"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2020-10-15-get-started-with-go/out/gen_out.cue
@@ -222,5 +222,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "e056e9073a2ef2120ff5374aed6cefcee2fae19318cc97fbf41689a7c4683aa5"
+Hash: "789e6c10637cf3fe655f69401380e942ea338bb78eed2e3a59388987fcae2f8c"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2020-10-19-go-fundamentals/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201112105706-464aa7e03365",
-		      "Sum": "h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=",
+		      "Version": "v0.0.2-0.20201112161106-44ae5cf00b09",
+		      "Sum": "h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=",
 		      "Replace": null
 		    },
 		    {
@@ -1680,27 +1680,6 @@ Steps: {
 		StepType:        1
 		Name:            "gomodinit_hello"
 	}
-	mkdir_hello: {
-		Stmts: [{
-			ComparisonOutput: ""
-			Output:           ""
-			ExitCode:         0
-			CmdStr:           "mkdir /home/gopher/hello"
-			Negated:          false
-		}, {
-			ComparisonOutput: ""
-			Output:           ""
-			ExitCode:         0
-			CmdStr:           "cd /home/gopher/hello"
-			Negated:          false
-		}]
-		Order:           10
-		InformationOnly: false
-		DoNotTrim:       false
-		Terminal:        "term1"
-		StepType:        1
-		Name:            "mkdir_hello"
-	}
 	greetings_gitpush: {
 		Stmts: [{
 			ComparisonOutput: """
@@ -1895,6 +1874,27 @@ Steps: {
 		StepType:        1
 		Name:            "mkdir_greetings"
 	}
+	mkdir_hello: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "mkdir /home/gopher/hello"
+			Negated:          false
+		}, {
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "cd /home/gopher/hello"
+			Negated:          false
+		}]
+		Order:           10
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "mkdir_hello"
+	}
 	pwd_home: {
 		Stmts: [{
 			ComparisonOutput: """
@@ -1938,5 +1938,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "17fe96bddae374019fde3b8f75686ef50d439c61f93d871797da70b3a35d847d"
+Hash: "eaf044b02dfeb14c05d0551c9b30d45ddfa2d1d283f54cb5500c61bce1e65082"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201112105706-464aa7e03365",
-		      "Sum": "h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=",
+		      "Version": "v0.0.2-0.20201112161106-44ae5cf00b09",
+		      "Sum": "h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=",
 		      "Replace": null
 		    },
 		    {
@@ -774,5 +774,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "28917659b5e4d043fa9c63bce4cc2a61fb5f4f324f7612e536cc5fc18689552b"
+Hash: "2407ac8472597eaf3d6342a5f5b8ad6c3148f12fb5ef6b823813286ed253bb45"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201112105706-464aa7e03365",
-		      "Sum": "h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=",
+		      "Version": "v0.0.2-0.20201112161106-44ae5cf00b09",
+		      "Sum": "h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=",
 		      "Replace": null
 		    },
 		    {
@@ -1311,5 +1311,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "f9c766ccc71e340f0212c9f921866bf6d7d50b24f9ffa27ffd8ae466aeab4045"
+Hash: "3f2162d48b339bdfb64b0aa99ba6c1a33a6f3c57bcf51bdd839f7e6dafa8e636"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-programs-standalone/out/gen_out.cue
+++ b/guides/2020-11-09-installing-programs-standalone/out/gen_out.cue
@@ -206,5 +206,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "ea934e76bf6437b428e8f82a42ea41782d52270f3045fc2b3413e6196691a87f"
+Hash: "1f8d538927f896b50df9179ee35bb04d1dd7ac219134130cce81b0ea976dd1ae"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -959,5 +959,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "36fbd3a2e583d0310e82fb1325c9575d8b6e042783c594fb7efc7ab3a052a32b"
+Hash: "6131742a0dcdebb40e71a0c7826447bd243c2d2d5ecf5b347a2ad59b0df919c6"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
+++ b/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
@@ -86,21 +86,23 @@ of the named environment variables to the given values.
 For more about environment variables, see 'go help environment'.
 $ go env -w GOPROXY=https://proxy.golang.org
 $ go get {{{.PUBLIC}}}
-go: downloading {{{.PUBLIC}}} v0.0.0-20201112145351-6c967f8a533a
-go: {{{.PUBLIC}}} upgrade => v0.0.0-20201112145351-6c967f8a533a
+go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
+$ go list -m -f {{.Version}} {{{.PUBLIC}}}
+v0.0.0-20060102150405-abcedf12345
 $ go get {{{.PRIVATE}}}
 go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 410 Gone
 	server response:
-	not found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+	not found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 	Confirm the import path was entered correctly.
 	If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
 $ go env -w GOPROXY=
 $ go get {{{.PRIVATE}}}
-go: downloading {{{.PRIVATE}}} v0.0.0-20201112145352-806167d7acb5
-go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: verifying module: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: 410 Gone
+go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 410 Gone
 	server response:
-	not found: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+	not found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 $ go help module-private
 The go command defaults to downloading modules from the public Go module
@@ -146,8 +148,10 @@ The 'go env -w' command (see 'go help env') can be used to set these variables
 for future go command invocations.
 $ go env -w GOPRIVATE={{{.PRIVATE}}}
 $ go get {{{.PRIVATE}}}
-go: downloading {{{.PRIVATE}}} v0.0.0-20201112145352-806167d7acb5
-go: {{{.PRIVATE}}} upgrade => v0.0.0-20201112145352-806167d7acb5
+go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
+$ go list -m -f {{.Version}} {{{.PRIVATE}}}
+v0.0.0-20060102150405-abcedf12345
 $ go run .
 public.Message(): This is a public safety announcement!
 private.Secret(): This is a top secret message... for your eyes only

--- a/guides/2020-11-12-working-with-private-modules/guide.cue
+++ b/guides/2020-11-12-working-with-private-modules/guide.cue
@@ -171,6 +171,14 @@ Steps: gopher_get_public_initial: preguide.#Command & {
 		"""
 }
 
+Steps: public_pseudo_version: preguide.#Command & {
+	InformationOnly: true
+	RandomReplace:   "v0.0.0-\(_#StablePsuedoversionSuffix)"
+	Source:          """
+		\(Defs.cmdgo.list) -m -f {{.Version}} \(Defs.public_mod)
+		"""
+}
+
 Steps: gopher_get_private_initial: preguide.#Command & {
 	Source: """
 		! \(Defs.cmdgo.get) \(Defs.private_mod)
@@ -205,6 +213,14 @@ Steps: goprivate_set_private: preguide.#Command & {
 Steps: gopher_get_private_goprivate: preguide.#Command & {
 	Source: """
 		\(Defs.cmdgo.get) \(Defs.private_mod)
+		"""
+}
+
+Steps: private_pseudo_version: preguide.#Command & {
+	InformationOnly: true
+	RandomReplace:   "v0.0.0-\(_#StablePsuedoversionSuffix)"
+	Source:          """
+		\(Defs.cmdgo.list) -m -f {{.Version}} \(Defs.private_mod)
 		"""
 }
 

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201112105706-464aa7e03365",
-		      "Sum": "h1:rIO+qeZcanEl9kEkrVEASR1EnjRZFW4cljBwiM7Iq7E=",
+		      "Version": "v0.0.2-0.20201112161106-44ae5cf00b09",
+		      "Sum": "h1:LKXLc0HG6uyfja8SUdSwjRefOn6t34hnxzdCTMzqunI=",
 		      "Replace": null
 		    },
 		    {
@@ -139,30 +139,52 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           20
+		Order:           22
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "gopher_run"
 	}
+	private_pseudo_version: {
+		Stmts: [{
+			ComparisonOutput: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			Output: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			ExitCode: 0
+			CmdStr:   "go list -m -f {{.Version}} {{{.PRIVATE}}}"
+			Negated:  false
+		}]
+		Order:           21
+		InformationOnly: true
+		DoNotTrim:       false
+		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "private_pseudo_version"
+	}
 	gopher_get_private_goprivate: {
 		Stmts: [{
 			ComparisonOutput: """
 
-				go: downloading {{{.PRIVATE}}} v0.0.0-20201112145352-806167d7acb5
-				go: {{{.PRIVATE}}} upgrade => v0.0.0-20201112145352-806167d7acb5
+				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
 				"""
 			Output: """
-				go: downloading {{{.PRIVATE}}} v0.0.0-20201112145352-806167d7acb5
-				go: {{{.PRIVATE}}} upgrade => v0.0.0-20201112145352-806167d7acb5
+				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ExitCode: 0
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			Negated:  false
 		}]
-		Order:           19
+		Order:           20
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -177,7 +199,7 @@ Steps: {
 			CmdStr:           "go env -w GOPRIVATE={{{.PRIVATE}}}"
 			Negated:          false
 		}]
-		Order:           18
+		Order:           19
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -189,16 +211,16 @@ Steps: {
 			ComparisonOutput: """
 
 				\t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
-				\tnot found: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+				\tnot found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\tserver response:
-				go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: verifying module: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: 410 Gone
-				go: downloading {{{.PRIVATE}}} v0.0.0-20201112145352-806167d7acb5
+				go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 410 Gone
+				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
 				"""
 			Output: """
-				go: downloading {{{.PRIVATE}}} v0.0.0-20201112145352-806167d7acb5
-				go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: verifying module: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: 410 Gone
+				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+				go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 410 Gone
 				\tserver response:
-				\tnot found: {{{.PRIVATE}}}@v0.0.0-20201112145352-806167d7acb5: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+				\tnot found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git fetch -f origin refs/heads/*:refs/heads/* refs/tags/*:refs/tags/* in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 
 				"""
@@ -206,7 +228,7 @@ Steps: {
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			Negated:  true
 		}]
-		Order:           16
+		Order:           17
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -221,7 +243,7 @@ Steps: {
 			CmdStr:           "go env -w GOPROXY="
 			Negated:          false
 		}]
-		Order:           15
+		Order:           16
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -235,14 +257,14 @@ Steps: {
 				\t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 				\tConfirm the import path was entered correctly.
 				\tIf this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
-				\tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+				\tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\tserver response:
 				go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 410 Gone
 				"""
 			Output: """
 				go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 410 Gone
 				\tserver response:
-				\tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/1579f2974f18ae2d93ad89f8eb7e23c7e418fa4b40c77b48fd0ac1a2e489856f: exit status 128:
+				\tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 				\tConfirm the import path was entered correctly.
 				\tIf this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
@@ -252,23 +274,45 @@ Steps: {
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			Negated:  true
 		}]
-		Order:           14
+		Order:           15
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "gopher_get_private_initial"
 	}
+	public_pseudo_version: {
+		Stmts: [{
+			ComparisonOutput: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			Output: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			ExitCode: 0
+			CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+			Negated:  false
+		}]
+		Order:           14
+		InformationOnly: true
+		DoNotTrim:       false
+		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "public_pseudo_version"
+	}
 	gopher_get_public_initial: {
 		Stmts: [{
 			ComparisonOutput: """
 
-				go: downloading {{{.PUBLIC}}} v0.0.0-20201112145351-6c967f8a533a
-				go: {{{.PUBLIC}}} upgrade => v0.0.0-20201112145351-6c967f8a533a
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
 				"""
 			Output: """
-				go: downloading {{{.PUBLIC}}} v0.0.0-20201112145351-6c967f8a533a
-				go: {{{.PUBLIC}}} upgrade => v0.0.0-20201112145351-6c967f8a533a
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ExitCode: 0
@@ -399,33 +443,6 @@ Steps: {
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "go_env_check_goproxy"
-	}
-	gopher_go_initial: {
-		Order: 8
-		Source: """
-			package main
-
-			import (
-			\t"fmt"
-
-			\t"{{{.PUBLIC}}}"
-			\t"{{{.PRIVATE}}}"
-			)
-
-			func main() {
-			\tfmt.Printf("public.Message(): %v\\n", public.Message())
-			\tfmt.Printf("private.Secret(): %v\\n", private.Secret())
-			}
-
-			"""
-		Renderer: {
-			RendererType: 1
-		}
-		Language: "go"
-		Target:   "/home/gopher/gopher/gopher.go"
-		Terminal: "term1"
-		StepType: 2
-		Name:     "gopher_go_initial"
 	}
 	gopher_init: {
 		Stmts: [{
@@ -658,27 +675,6 @@ Steps: {
 		StepType:        1
 		Name:            "public_init"
 	}
-	goversion: {
-		Stmts: [{
-			ComparisonOutput: """
-				go version go1.15.3 linux/amd64
-
-				"""
-			Output: """
-				go version go1.15.3 linux/amd64
-
-				"""
-			ExitCode: 0
-			CmdStr:   "go version"
-			Negated:  false
-		}]
-		Order:           0
-		InformationOnly: false
-		DoNotTrim:       false
-		Terminal:        "term1"
-		StepType:        1
-		Name:            "goversion"
-	}
 	go_help_modprivate: {
 		Stmts: [{
 			ComparisonOutput: """
@@ -773,13 +769,61 @@ Steps: {
 			CmdStr:   "go help module-private"
 			Negated:  false
 		}]
-		Order:           17
+		Order:           18
 		InformationOnly: true
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "go_help_modprivate"
 	}
+	gopher_go_initial: {
+		Order: 8
+		Source: """
+			package main
+
+			import (
+			\t"fmt"
+
+			\t"{{{.PUBLIC}}}"
+			\t"{{{.PRIVATE}}}"
+			)
+
+			func main() {
+			\tfmt.Printf("public.Message(): %v\\n", public.Message())
+			\tfmt.Printf("private.Secret(): %v\\n", private.Secret())
+			}
+
+			"""
+		Renderer: {
+			RendererType: 1
+		}
+		Language: "go"
+		Target:   "/home/gopher/gopher/gopher.go"
+		Terminal: "term1"
+		StepType: 2
+		Name:     "gopher_go_initial"
+	}
+	goversion: {
+		Stmts: [{
+			ComparisonOutput: """
+				go version go1.15.3 linux/amd64
+
+				"""
+			Output: """
+				go version go1.15.3 linux/amd64
+
+				"""
+			ExitCode: 0
+			CmdStr:   "go version"
+			Negated:  false
+		}]
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "goversion"
+	}
 }
-Hash: "97acfd3823aa162014df60580ecdd53ff64dfefefc1710024493d383885bca1c"
+Hash: "c48c3cc74bed64075c34d9c375a4e1af669c9546567226ce4f27b7f29431c6d0"
 Delims: ["{{{", "}}}"]


### PR DESCRIPTION
Otherwise it will always result in changes after a
PREGUIDE_SKIP_CACHE=true run.

Also upgrade to the latest preguide which includes a fix for sanitising
the output of go get when it includes a module VCS cache path