### PR TITLE
guides: fix misspelling

### DIFF
--- a/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
+++ b/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
@@ -104,7 +104,7 @@ remote: Processed 1 references in total
 ### The `gopher` module
 
 Now create a `gopher` module to try out the `public` and `private` modules. Unlike
-the `public` and `private` modules, you will not publisht the `gopher` module; it
+the `public` and `private` modules, you will not publish the `gopher` module; it
 will be local only:
 
 ```.term1

--- a/guides/2020-11-12-working-with-private-modules/en.markdown
+++ b/guides/2020-11-12-working-with-private-modules/en.markdown
@@ -58,7 +58,7 @@ Commit and push this initial version:
 ### The `<!--ref:gopher-->` module
 
 Now create a `<!--ref: gopher-->` module to try out the `<!--ref: public-->` and `<!--ref:private-->` modules. Unlike
-the `<!--ref: public-->` and `<!--ref:private-->` modules, you will not publisht the `<!--ref: gopher-->` module; it
+the `<!--ref: public-->` and `<!--ref:private-->` modules, you will not publish the `<!--ref: gopher-->` module; it
 will be local only:
 
 <!--step: gopher_init-->


### PR DESCRIPTION
s/publisht/publish