### PR TITLE
guides: fix a bug in the private modules guide

### DIFF
--- a/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
+++ b/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
@@ -44,12 +44,12 @@ Start by initialising your  `public` module:
 ```.term1
 $ mkdir /home/gopher/public
 $ cd /home/gopher/public
-$ go mod init public
-go: creating new go.mod: module public
+$ go mod init {% raw %}{{{.PUBLIC}}}{% endraw %}
+go: creating new go.mod: module {% raw %}{{{.PUBLIC}}}{% endraw %}
 $ git init -q
 $ git remote add origin https://{% raw %}{{{.PUBLIC}}}{% endraw %}.git
 ```
-{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL3B1YmxpYwpjZCAvaG9tZS9nb3BoZXIvcHVibGljCmdvIG1vZCBpbml0IHB1YmxpYwpnaXQgaW5pdCAtcQpnaXQgcmVtb3RlIGFkZCBvcmlnaW4gaHR0cHM6Ly97e3suUFVCTElDfX19LmdpdAo="}
+{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL3B1YmxpYwpjZCAvaG9tZS9nb3BoZXIvcHVibGljCmdvIG1vZCBpbml0IHt7ey5QVUJMSUN9fX0KZ2l0IGluaXQgLXEKZ2l0IHJlbW90ZSBhZGQgb3JpZ2luIGh0dHBzOi8ve3t7LlBVQkxJQ319fS5naXQK"}
 
 Create an initial version of the `Message()` in `public.go`:
 
@@ -63,25 +63,25 @@ func Message() string {
 Commit and push this initial version:
 
 ```.term1
-$ git add public.go
+$ git add public.go go.mod
 $ git commit -q -m 'Initial commit of public module'
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 ```
-{:data-command-src="Z2l0IGFkZCBwdWJsaWMuZ28KZ2l0IGNvbW1pdCAtcSAtbSAnSW5pdGlhbCBjb21taXQgb2YgcHVibGljIG1vZHVsZScKZ2l0IHB1c2ggLXEgb3JpZ2luIG1haW4K"}
+{:data-command-src="Z2l0IGFkZCBwdWJsaWMuZ28gZ28ubW9kCmdpdCBjb21taXQgLXEgLW0gJ0luaXRpYWwgY29tbWl0IG9mIHB1YmxpYyBtb2R1bGUnCmdpdCBwdXNoIC1xIG9yaWdpbiBtYWluCg=="}
 
 Now do the same for the `private` module:
 
 ```.term1
 $ mkdir /home/gopher/private
 $ cd /home/gopher/private
-$ go mod init private
-go: creating new go.mod: module private
+$ go mod init {% raw %}{{{.PRIVATE}}}{% endraw %}
+go: creating new go.mod: module {% raw %}{{{.PRIVATE}}}{% endraw %}
 $ git init -q
 $ git remote add origin https://{% raw %}{{{.PRIVATE}}}{% endraw %}.git
 ```
-{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL3ByaXZhdGUKY2QgL2hvbWUvZ29waGVyL3ByaXZhdGUKZ28gbW9kIGluaXQgcHJpdmF0ZQpnaXQgaW5pdCAtcQpnaXQgcmVtb3RlIGFkZCBvcmlnaW4gaHR0cHM6Ly97e3suUFJJVkFURX19fS5naXQK"}
+{:data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL3ByaXZhdGUKY2QgL2hvbWUvZ29waGVyL3ByaXZhdGUKZ28gbW9kIGluaXQge3t7LlBSSVZBVEV9fX0KZ2l0IGluaXQgLXEKZ2l0IHJlbW90ZSBhZGQgb3JpZ2luIGh0dHBzOi8ve3t7LlBSSVZBVEV9fX0uZ2l0Cg=="}
 
 _Note: the `private` source code repository at https://{% raw %}{{{.PRIVATE}}}{% endraw %}.git was automatically created for you when this
 guide loaded, much like https://{% raw %}{{{.PUBLIC}}}{% endraw %}.git was created for the `public` module. However, the
@@ -100,13 +100,13 @@ func Secret() string {
 Commit and push this initial version:
 
 ```.term1
-$ git add private.go
+$ git add private.go go.mod
 $ git commit -q -m 'Initial commit of private module'
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 ```
-{:data-command-src="Z2l0IGFkZCBwcml2YXRlLmdvCmdpdCBjb21taXQgLXEgLW0gJ0luaXRpYWwgY29tbWl0IG9mIHByaXZhdGUgbW9kdWxlJwpnaXQgcHVzaCAtcSBvcmlnaW4gbWFpbgo="}
+{:data-command-src="Z2l0IGFkZCBwcml2YXRlLmdvIGdvLm1vZApnaXQgY29tbWl0IC1xIC1tICdJbml0aWFsIGNvbW1pdCBvZiBwcml2YXRlIG1vZHVsZScKZ2l0IHB1c2ggLXEgb3JpZ2luIG1haW4K"}
 
 ### The `gopher` module
 

--- a/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
+++ b/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
@@ -2,8 +2,8 @@ $ go version
 go version go1.15.5 linux/amd64
 $ mkdir /home/gopher/public
 $ cd /home/gopher/public
-$ go mod init public
-go: creating new go.mod: module public
+$ go mod init {{{.PUBLIC}}}
+go: creating new go.mod: module {{{.PUBLIC}}}
 $ git init -q
 $ git remote add origin https://{{{.PUBLIC}}}.git
 $ cat <<EOD > /home/gopher/public/public.go
@@ -14,15 +14,15 @@ func Message() string {
 }
 
 EOD
-$ git add public.go
+$ git add public.go go.mod
 $ git commit -q -m 'Initial commit of public module'
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 $ mkdir /home/gopher/private
 $ cd /home/gopher/private
-$ go mod init private
-go: creating new go.mod: module private
+$ go mod init {{{.PRIVATE}}}
+go: creating new go.mod: module {{{.PRIVATE}}}
 $ git init -q
 $ git remote add origin https://{{{.PRIVATE}}}.git
 $ cat <<EOD > /home/gopher/private/private.go
@@ -33,7 +33,7 @@ func Secret() string {
 }
 
 EOD
-$ git add private.go
+$ git add private.go go.mod
 $ git commit -q -m 'Initial commit of private module'
 $ git push -q origin main
 remote: . Processing 1 references        

--- a/guides/2020-11-12-working-with-private-modules/guide.cue
+++ b/guides/2020-11-12-working-with-private-modules/guide.cue
@@ -56,7 +56,7 @@ Steps: public_init: preguide.#Command & {
 	Source: """
 		mkdir \(Defs.public_dir)
 		cd \(Defs.public_dir)
-		\(Defs.cmdgo.modinit) \(Defs.public)
+		\(Defs.cmdgo.modinit) \(Defs.public_mod)
 		\(Defs.git.init)
 		\(Defs.git.remote) add origin \(Defs.public_vcs)
 		"""
@@ -76,7 +76,7 @@ Steps: public_go_initial: preguide.#Upload & {
 
 Steps: public_initial_commit: preguide.#Command & {
 	Source: """
-		\(Defs.git.add) \(Defs.public_go)
+		\(Defs.git.add) \(Defs.public_go) go.mod
 		\(Defs.git.commit) -m 'Initial commit of \(Defs.public) module'
 		\(Defs.git.push) origin main
 		"""
@@ -86,7 +86,7 @@ Steps: private_init: preguide.#Command & {
 	Source: """
 		mkdir \(Defs.private_dir)
 		cd \(Defs.private_dir)
-		\(Defs.cmdgo.modinit) \(Defs.private)
+		\(Defs.cmdgo.modinit) \(Defs.private_mod)
 		\(Defs.git.init)
 		\(Defs.git.remote) add origin \(Defs.private_vcs)
 		"""
@@ -106,7 +106,7 @@ Steps: private_go_initial: preguide.#Upload & {
 
 Steps: private_initial_commit: preguide.#Command & {
 	Source: """
-		\(Defs.git.add) \(Defs.private_go)
+		\(Defs.git.add) \(Defs.private_go) go.mod
 		\(Defs.git.commit) -m 'Initial commit of \(Defs.private) module'
 		\(Defs.git.push) origin main
 		"""

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -488,7 +488,7 @@ Steps: {
 			ComparisonOutput: ""
 			Output:           ""
 			ExitCode:         0
-			CmdStr:           "git add private.go"
+			CmdStr:           "git add private.go go.mod"
 			Negated:          false
 		}, {
 			ComparisonOutput: ""
@@ -552,15 +552,15 @@ Steps: {
 			Negated:          false
 		}, {
 			ComparisonOutput: """
-				go: creating new go.mod: module private
+				go: creating new go.mod: module {{{.PRIVATE}}}
 
 				"""
 			Output: """
-				go: creating new go.mod: module private
+				go: creating new go.mod: module {{{.PRIVATE}}}
 
 				"""
 			ExitCode: 0
-			CmdStr:   "go mod init private"
+			CmdStr:   "go mod init {{{.PRIVATE}}}"
 			Negated:  false
 		}, {
 			ComparisonOutput: ""
@@ -587,7 +587,7 @@ Steps: {
 			ComparisonOutput: ""
 			Output:           ""
 			ExitCode:         0
-			CmdStr:           "git add public.go"
+			CmdStr:           "git add public.go go.mod"
 			Negated:          false
 		}, {
 			ComparisonOutput: ""
@@ -651,15 +651,15 @@ Steps: {
 			Negated:          false
 		}, {
 			ComparisonOutput: """
-				go: creating new go.mod: module public
+				go: creating new go.mod: module {{{.PUBLIC}}}
 
 				"""
 			Output: """
-				go: creating new go.mod: module public
+				go: creating new go.mod: module {{{.PUBLIC}}}
 
 				"""
 			ExitCode: 0
-			CmdStr:   "go mod init public"
+			CmdStr:   "go mod init {{{.PUBLIC}}}"
 			Negated:  false
 		}, {
 			ComparisonOutput: ""
@@ -831,5 +831,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "b36b596c992ffd674c04a549d541eb79b3b170978d2187bd32bd13abf0c24fb2"
+Hash: "ed339105de4ec3c3cc8979d4f4ec5ddb598fd7e8f7f6a6650d0b9c6fe347d987"
 Delims: ["{{{", "}}}"]


### PR DESCRIPTION
go.mod files were not git add-ed, hence were never published. This hid
the fact that both modules in fact had the wrong path, i.e. they were
not fully qualified.

Thanks to @ardan-bkennedy for spotting this.

The automated fix that catches these sorts of issues is covered by
play-with-go/preguide#153.