### PR TITLE
guides: fix bad git add commands

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -161,10 +161,10 @@ $ git remote add origin https://{% raw %}{{{.GREETINGS}}}{% endraw %}.git
 Add and commit the `greetings.go` file you created earlier:
 
 ```.term1
-$ git add greetings.go
+$ git add go.mod greetings.go
 $ git commit -q -m 'Initial commit'
 ```
-{:data-command-src="Z2l0IGFkZCBncmVldGluZ3MuZ28KZ2l0IGNvbW1pdCAtcSAtbSAnSW5pdGlhbCBjb21taXQnCg=="}
+{:data-command-src="Z2l0IGFkZCBnby5tb2QgZ3JlZXRpbmdzLmdvCmdpdCBjb21taXQgLXEgLW0gJ0luaXRpYWwgY29tbWl0Jwo="}
 
 Publish this commit by pushing it to the remote repository:
 

--- a/_posts/2020-09-01-basic-go-modules-example_go115_en.markdown
+++ b/_posts/2020-09-01-basic-go-modules-example_go115_en.markdown
@@ -39,13 +39,13 @@ func main() {
 Commit and push:
 
 ```.term1
-$ git add README.md main.go
+$ git add go.mod README.md main.go
 $ git commit -q -m "Initial commit"
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 ```
-{:data-command-src="Z2l0IGFkZCBSRUFETUUubWQgbWFpbi5nbwpnaXQgY29tbWl0IC1xIC1tICJJbml0aWFsIGNvbW1pdCIKZ2l0IHB1c2ggLXEgb3JpZ2luIG1haW4K"}
+{:data-command-src="Z2l0IGFkZCBnby5tb2QgUkVBRE1FLm1kIG1haW4uZ28KZ2l0IGNvbW1pdCAtcSAtbSAiSW5pdGlhbCBjb21taXQiCmdpdCBwdXNoIC1xIG9yaWdpbiBtYWluCg=="}
 
 Use the module:
 

--- a/guides/2018-10-19-go-fundamentals/go115_en_log.txt
+++ b/guides/2018-10-19-go-fundamentals/go115_en_log.txt
@@ -39,8 +39,9 @@ func Hello(name string) string {
 EOD
 $ git init -q
 $ git remote add origin https://{{{.GREETINGS}}}.git
-$ git add greetings.go
+$ git add go.mod greetings.go
 $ git commit -q -m 'Initial commit'
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
@@ -97,6 +98,7 @@ func Hello(name string) (string, error) {
 EOD
 $ git add greetings.go
 $ git commit -q -m 'Added error handling'
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ greetings_error_commit=$(git rev-parse HEAD)
 $ git rev-parse HEAD
 v0.0.0-20060102150405-abcedf12345
@@ -193,6 +195,7 @@ func randomFormat() string {
 EOD
 $ git add greetings.go
 $ git commit -q -m 'Added random format'
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ greetings_random_commit=$(git rev-parse HEAD)
 $ git rev-parse HEAD
 v0.0.0-20060102150405-abcedf12345

--- a/guides/2018-10-19-go-fundamentals/guide.cue
+++ b/guides/2018-10-19-go-fundamentals/guide.cue
@@ -116,8 +116,15 @@ Steps: greetings_gitinit: preguide.#Command & {
 
 Steps: greetings_gitadd: preguide.#Command & {
 	Source: """
-		\(Defs.git.add) \(Defs.greetings_go)
+		\(Defs.git.add) go.mod \(Defs.greetings_go)
 		\(Defs.git.commit) -m 'Initial commit'
+		"""
+}
+
+Steps: greetings_check_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 
@@ -218,6 +225,13 @@ Steps: commit_greetings_error_handling: preguide.#Command & {
 	Source: """
 		\(Defs.git.add) \(Defs.greetings_go)
 		\(Defs.git.commit) -m 'Added error handling'
+		"""
+}
+
+Steps: greetings_check_error_handling_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 
@@ -365,6 +379,13 @@ Steps: greeings_commit_random: preguide.#Command & {
 	Source: """
 		\(Defs.git.add) \(Defs.greetings_go)
 		\(Defs.git.commit) -m 'Added random format'
+		"""
+}
+
+Steps: greetings_check_random_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -143,7 +143,7 @@ Steps: {
 			CmdStr:   "hello"
 			Negated:  false
 		}]
-		Order:           55
+		Order:           58
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -158,7 +158,7 @@ Steps: {
 			CmdStr:           "go install"
 			Negated:          false
 		}]
-		Order:           54
+		Order:           57
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -179,7 +179,7 @@ Steps: {
 			CmdStr:           "export PATH=\"$goinstalldir:$PATH\""
 			Negated:          false
 		}]
-		Order:           53
+		Order:           56
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -200,7 +200,7 @@ Steps: {
 			CmdStr:   "go list -f '{{.Target}}'"
 			Negated:  false
 		}]
-		Order:           52
+		Order:           55
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -215,7 +215,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/hello"
 			Negated:          false
 		}]
-		Order:           51
+		Order:           54
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -238,7 +238,7 @@ Steps: {
 			CmdStr:   "go test"
 			Negated:  false
 		}]
-		Order:           50
+		Order:           53
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -246,7 +246,7 @@ Steps: {
 		Name:            "greetings_check_tests_pass"
 	}
 	greetings_go_restore: {
-		Order: 49
+		Order: 52
 		Source: """
 			package greetings
 
@@ -411,7 +411,7 @@ Steps: {
 			CmdStr:   "go test"
 			Negated:  true
 		}]
-		Order:           48
+		Order:           51
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -419,7 +419,7 @@ Steps: {
 		Name:            "greetings_run_tests_fail"
 	}
 	greetings_go_break: {
-		Order: 47
+		Order: 50
 		Source: """
 			package greetings
 
@@ -600,7 +600,7 @@ Steps: {
 			CmdStr:   "go test -v"
 			Negated:  false
 		}]
-		Order:           46
+		Order:           49
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -608,7 +608,7 @@ Steps: {
 		Name:            "greetings_run_tests"
 	}
 	greetings_create_greetings_test_go: {
-		Order: 45
+		Order: 48
 		Source: """
 			package greetings
 
@@ -655,7 +655,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/greetings"
 			Negated:          false
 		}]
-		Order:           44
+		Order:           47
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -676,7 +676,7 @@ Steps: {
 			CmdStr:   "go run hello.go"
 			Negated:  false
 		}]
-		Order:           43
+		Order:           46
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -684,7 +684,7 @@ Steps: {
 		Name:            "hello_run_multiple"
 	}
 	hello_go_call_multiple: {
-		Order: 42
+		Order: 45
 		Source: """
 			package main
 
@@ -782,7 +782,7 @@ Steps: {
 			CmdStr:   "cat go.mod"
 			Negated:  false
 		}]
-		Order:           41
+		Order:           44
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -797,7 +797,7 @@ Steps: {
 			CmdStr:           "go mod edit -replace {{{.GREETINGS}}}=/home/gopher/greetings"
 			Negated:          false
 		}]
-		Order:           40
+		Order:           43
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -812,7 +812,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/hello"
 			Negated:          false
 		}]
-		Order:           39
+		Order:           42
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -820,7 +820,7 @@ Steps: {
 		Name:            "hello_use_multiple"
 	}
 	greetings_go_multiple_people: {
-		Order: 38
+		Order: 41
 		Source: """
 			package greetings
 
@@ -951,7 +951,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/greetings"
 			Negated:          false
 		}]
-		Order:           37
+		Order:           40
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -984,7 +984,7 @@ Steps: {
 			CmdStr:   "go run hello.go"
 			Negated:  false
 		}]
-		Order:           36
+		Order:           39
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -992,7 +992,7 @@ Steps: {
 		Name:            "hello_run_random"
 	}
 	hello_go_readd_gladys: {
-		Order: 35
+		Order: 38
 		Source: """
 			package main
 
@@ -1078,7 +1078,7 @@ Steps: {
 			CmdStr:   "go list -m -f {{.Version}} {{{.GREETINGS}}}"
 			Negated:  false
 		}]
-		Order:           34
+		Order:           37
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -1108,7 +1108,7 @@ Steps: {
 			CmdStr:   "go get {{{.GREETINGS}}}@$greetings_random_commit"
 			Negated:  false
 		}]
-		Order:           33
+		Order:           36
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1131,7 +1131,7 @@ Steps: {
 			CmdStr:   "git push -q origin main"
 			Negated:  false
 		}]
-		Order:           32
+		Order:           35
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1152,7 +1152,7 @@ Steps: {
 			CmdStr:   "git rev-parse HEAD"
 			Negated:  false
 		}]
-		Order:           31
+		Order:           34
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -1168,12 +1168,27 @@ Steps: {
 			CmdStr:           "greetings_random_commit=$(git rev-parse HEAD)"
 			Negated:          false
 		}]
-		Order:           30
+		Order:           33
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "greetings_random_commit"
+	}
+	greetings_check_random_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           32
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "greetings_check_random_porcelain"
 	}
 	greeings_commit_random: {
 		Stmts: [{
@@ -1189,7 +1204,7 @@ Steps: {
 			CmdStr:           "git commit -q -m 'Added random format'"
 			Negated:          false
 		}]
-		Order:           29
+		Order:           31
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1197,7 +1212,7 @@ Steps: {
 		Name:            "greeings_commit_random"
 	}
 	update_greetings_go_random: {
-		Order: 28
+		Order: 30
 		Source: """
 			package greetings
 
@@ -1275,7 +1290,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/greetings"
 			Negated:          false
 		}]
-		Order:           27
+		Order:           29
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1298,7 +1313,7 @@ Steps: {
 			CmdStr:   "go run hello.go"
 			Negated:  true
 		}]
-		Order:           26
+		Order:           28
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1306,7 +1321,7 @@ Steps: {
 		Name:            "run_hello_error"
 	}
 	update_hello_go_error: {
-		Order: 25
+		Order: 27
 		Source: """
 			package main
 
@@ -1377,7 +1392,7 @@ Steps: {
 			CmdStr:   "go list -m -f {{.Version}} {{{.GREETINGS}}}"
 			Negated:  false
 		}]
-		Order:           24
+		Order:           26
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -1401,7 +1416,7 @@ Steps: {
 			CmdStr:   "go get {{{.GREETINGS}}}@$greetings_error_commit"
 			Negated:  false
 		}]
-		Order:           23
+		Order:           25
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1416,7 +1431,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/hello"
 			Negated:          false
 		}]
-		Order:           22
+		Order:           24
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1439,7 +1454,7 @@ Steps: {
 			CmdStr:   "git push -q origin main"
 			Negated:  false
 		}]
-		Order:           21
+		Order:           23
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1460,7 +1475,7 @@ Steps: {
 			CmdStr:   "git rev-parse HEAD"
 			Negated:  false
 		}]
-		Order:           20
+		Order:           22
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -1476,12 +1491,27 @@ Steps: {
 			CmdStr:           "greetings_error_commit=$(git rev-parse HEAD)"
 			Negated:          false
 		}]
-		Order:           19
+		Order:           21
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "greetings_error_commit"
+	}
+	greetings_check_error_handling_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           20
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "greetings_check_error_handling_porcelain"
 	}
 	commit_greetings_error_handling: {
 		Stmts: [{
@@ -1497,7 +1527,7 @@ Steps: {
 			CmdStr:           "git commit -q -m 'Added error handling'"
 			Negated:          false
 		}]
-		Order:           18
+		Order:           19
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1505,7 +1535,7 @@ Steps: {
 		Name:            "commit_greetings_error_handling"
 	}
 	update_greetings_go: {
-		Order: 17
+		Order: 18
 		Source: """
 			package greetings
 
@@ -1559,7 +1589,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/greetings"
 			Negated:          false
 		}]
-		Order:           16
+		Order:           17
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1586,7 +1616,7 @@ Steps: {
 			CmdStr:   "./hello"
 			Negated:  false
 		}]
-		Order:           15
+		Order:           16
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1594,7 +1624,7 @@ Steps: {
 		Name:            "buildrun_hello"
 	}
 	create_hellogo: {
-		Order: 14
+		Order: 15
 		Source: """
 			package main
 
@@ -1634,7 +1664,7 @@ Steps: {
 			CmdStr:   "go list -m -f {{.Version}} {{{.GREETINGS}}}"
 			Negated:  false
 		}]
-		Order:           13
+		Order:           14
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -1658,7 +1688,7 @@ Steps: {
 			CmdStr:   "go get {{{.GREETINGS}}}"
 			Negated:  false
 		}]
-		Order:           12
+		Order:           13
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1679,7 +1709,7 @@ Steps: {
 			CmdStr:   "go mod init {{{.HELLO}}}"
 			Negated:  false
 		}]
-		Order:           11
+		Order:           12
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1700,7 +1730,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/hello"
 			Negated:          false
 		}]
-		Order:           10
+		Order:           11
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1723,19 +1753,34 @@ Steps: {
 			CmdStr:   "git push -q origin main"
 			Negated:  false
 		}]
-		Order:           9
+		Order:           10
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "greetings_gitpush"
 	}
+	greetings_check_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           9
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "greetings_check_porcelain"
+	}
 	greetings_gitadd: {
 		Stmts: [{
 			ComparisonOutput: ""
 			Output:           ""
 			ExitCode:         0
-			CmdStr:           "git add greetings.go"
+			CmdStr:           "git add go.mod greetings.go"
 			Negated:          false
 		}, {
 			ComparisonOutput: ""
@@ -1944,5 +1989,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "27c26bc97a3d22b1b112069921e7b4fc79d6e8009cf112876d82cf143055f471"
+Hash: "5787d51f21cb5b6a43bd4f5166e4835fbad8690bea70607fcbf340c1be64a46f"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/go115_en_log.txt
+++ b/guides/2020-09-01-basic-go-modules-example/go115_en_log.txt
@@ -17,11 +17,12 @@ func main() {
 }
 
 EOD
-$ git add README.md main.go
+$ git add go.mod README.md main.go
 $ git commit -q -m "Initial commit"
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ mkdir /home/gopher/mod2
 $ cd /home/gopher/mod2
 $ go mod init mod.com

--- a/guides/2020-09-01-basic-go-modules-example/guide.cue
+++ b/guides/2020-09-01-basic-go-modules-example/guide.cue
@@ -64,9 +64,16 @@ Steps: create_main: preguide.#Upload & {
 
 Steps: commit_and_push: preguide.#Command & {
 	Source: """
-		\(Defs.git.add) README.md main.go
+		\(Defs.git.add) go.mod README.md main.go
 		\(Defs.git.commit) -m "Initial commit"
 		\(Defs.git.push) origin main
+		"""
+}
+
+Steps: check_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -139,7 +139,7 @@ Steps: {
 			CmdStr:   "go list -m -f {{.Version}} {{{.REPO1}}}"
 			Negated:  false
 		}]
-		Order:           5
+		Order:           6
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -199,19 +199,34 @@ Steps: {
 			CmdStr:   "go run {{{.REPO1}}}"
 			Negated:  false
 		}]
-		Order:           4
+		Order:           5
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "use_module"
 	}
+	check_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           4
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "check_porcelain"
+	}
 	commit_and_push: {
 		Stmts: [{
 			ComparisonOutput: ""
 			Output:           ""
 			ExitCode:         0
-			CmdStr:           "git add README.md main.go"
+			CmdStr:           "git add go.mod README.md main.go"
 			Negated:          false
 		}, {
 			ComparisonOutput: ""
@@ -320,5 +335,5 @@ Steps: {
 		Name:            "create_module"
 	}
 }
-Hash: "088d3bd3b5fc11021bafe5764fdb2e527f5ea4753ba8698fe5278ffee9a8144e"
+Hash: "a9ec65f3024c4cde951248811d28536a8e0bcfd721e5a3fe60f6323f66252835"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/go116_en_log.txt
+++ b/guides/2020-11-08-retract-module-versions/go116_en_log.txt
@@ -20,6 +20,7 @@ $ git commit -q -m "Initial commit"
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ git tag v0.1.0
 $ git push -q origin v0.1.0
 remote: . Processing 1 references        
@@ -61,6 +62,7 @@ $ git commit -q -m "Switch Go proverb to something more famous"
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ git tag v0.2.0
 $ git push -q origin v0.2.0
 remote: . Processing 1 references        
@@ -105,6 +107,7 @@ $ git tag v0.3.0
 $ git push -q origin v0.3.0
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ cd /home/gopher/gopher
 $ go get {{{.PROVERB}}}@v0.3.0
 go: downloading {{{.PROVERB}}} v0.3.0
@@ -144,6 +147,7 @@ $ git commit -q -m "Add Life() proverb"
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ git tag v1.0.0
 $ git push -q origin v1.0.0
 remote: . Processing 1 references        
@@ -175,6 +179,7 @@ $ git tag v1.0.1
 $ git push -q origin v1.0.1
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ cd /home/gopher/gopher
 $ (cd $(mktemp -d); export GOPATH=$(mktemp -d); go mod init mod.com; go get -x {{{.PROVERB}}}@v0.4.0; go get -x {{{.PROVERB}}}@v1.0.0; go get -x {{{.PROVERB}}}@v1.0.1; sleep 1m) >/dev/null 2>&1
 $ go get {{{.PROVERB}}}@v1.0.0

--- a/guides/2020-11-08-retract-module-versions/guide.cue
+++ b/guides/2020-11-08-retract-module-versions/guide.cue
@@ -79,6 +79,13 @@ Steps: proverb_initial_commit: preguide.#Command & {
 		"""
 }
 
+Steps: proverb_check_initial_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
 Steps: proverb_tag_v010: preguide.#Command & {
 	Source: """
 		\(Defs.git.tag) \(Defs.proverb_v010)
@@ -152,6 +159,13 @@ Steps: proverb_concurrency_commit: preguide.#Command & {
 		"""
 }
 
+Steps: proverb_check_concurrency_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
 Steps: proverb_tag_v020: preguide.#Command & {
 	Source: """
 		\(Defs.git.tag) \(Defs.proverb_v020)
@@ -219,6 +233,13 @@ Steps: proverb_tag_v030: preguide.#Command & {
 		\(Defs.git.push) origin main
 		\(Defs.git.tag) \(Defs.proverb_v030)
 		\(Defs.git.push) origin \(Defs.proverb_v030)
+		"""
+}
+
+Steps: proverb_check_v030_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 
@@ -310,6 +331,13 @@ Steps: proverb_life_commit: preguide.#Command & {
 		"""
 }
 
+Steps: proverb_check_v100_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
 Steps: proverb_tag_v100: preguide.#Command & {
 	Source: """
 		\(Defs.git.tag) \(Defs.proverb_v100)
@@ -350,6 +378,13 @@ Steps: proverb_tag_v101: preguide.#Command & {
 		\(Defs.git.push) origin main
 		\(Defs.git.tag) \(Defs.proverb_v101)
 		\(Defs.git.push) origin \(Defs.proverb_v101)
+		"""
+}
+
+Steps: proverb_check_v101_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -141,7 +141,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           43
+		Order:           48
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -149,7 +149,7 @@ Steps: {
 		Name:            "gopher_run_life_proverb"
 	}
 	gopher_go_update_life_proverb: {
-		Order: 42
+		Order: 47
 		Source: """
 			package main
 
@@ -202,7 +202,7 @@ Steps: {
 			CmdStr:   "go list -m -versions {{{.PROVERB}}}"
 			Negated:  false
 		}]
-		Order:           41
+		Order:           46
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -223,7 +223,7 @@ Steps: {
 			CmdStr:   "go list -m -versions -retracted {{{.PROVERB}}}"
 			Negated:  false
 		}]
-		Order:           40
+		Order:           45
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -238,7 +238,7 @@ Steps: {
 			CmdStr:           "sleep 1m"
 			Negated:          false
 		}]
-		Order:           39
+		Order:           44
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -291,7 +291,7 @@ Steps: {
 			CmdStr:   "go get {{{.PROVERB}}}@v0.4.0"
 			Negated:  false
 		}]
-		Order:           38
+		Order:           43
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -306,7 +306,7 @@ Steps: {
 			CmdStr:           "(cd $(mktemp -d); export GOPATH=$(mktemp -d); go mod init mod.com; go get -x {{{.PROVERB}}}@v0.4.0; go get -x {{{.PROVERB}}}@v1.0.0; go get -x {{{.PROVERB}}}@v1.0.1; sleep 1m) >/dev/null 2>&1"
 			Negated:          false
 		}]
-		Order:           37
+		Order:           42
 		InformationOnly: true
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -321,12 +321,27 @@ Steps: {
 			CmdStr:           "cd /home/gopher/gopher"
 			Negated:          false
 		}]
-		Order:           36
+		Order:           41
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "gopher_cd_use_v100"
+	}
+	proverb_check_v101_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           40
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "proverb_check_v101_porcelain"
 	}
 	proverb_tag_v101: {
 		Stmts: [{
@@ -376,7 +391,7 @@ Steps: {
 			CmdStr:   "git push -q origin v1.0.1"
 			Negated:  false
 		}]
-		Order:           35
+		Order:           39
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -384,7 +399,7 @@ Steps: {
 		Name:            "proverb_tag_v101"
 	}
 	proverb_retract_v100: {
-		Order: 34
+		Order: 38
 		Source: """
 			module {{{.PROVERB}}}
 
@@ -439,7 +454,7 @@ Steps: {
 			CmdStr:   "git push -q origin v0.4.0"
 			Negated:  false
 		}]
-		Order:           33
+		Order:           37
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -468,12 +483,27 @@ Steps: {
 			CmdStr:   "git push -q origin v1.0.0"
 			Negated:  false
 		}]
-		Order:           32
+		Order:           36
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "proverb_tag_v100"
+	}
+	proverb_check_v100_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           35
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "proverb_check_v100_porcelain"
 	}
 	proverb_life_commit: {
 		Stmts: [{
@@ -503,7 +533,7 @@ Steps: {
 			CmdStr:   "git push -q origin main"
 			Negated:  false
 		}]
-		Order:           31
+		Order:           34
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -511,7 +541,7 @@ Steps: {
 		Name:            "proverb_life_commit"
 	}
 	proverb_go_life_advice: {
-		Order: 30
+		Order: 33
 		Source: """
 			package proverb
 
@@ -552,7 +582,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/proverb"
 			Negated:          false
 		}]
-		Order:           29
+		Order:           32
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -567,7 +597,7 @@ Steps: {
 			CmdStr:           "go get {{{.PROVERB}}}@latest"
 			Negated:          false
 		}]
-		Order:           28
+		Order:           31
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -590,7 +620,7 @@ Steps: {
 			CmdStr:   "go list -m -u all"
 			Negated:  false
 		}]
-		Order:           27
+		Order:           30
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -611,7 +641,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           26
+		Order:           29
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -634,7 +664,7 @@ Steps: {
 			CmdStr:   "go get {{{.PROVERB}}}@v0.2.0"
 			Negated:  false
 		}]
-		Order:           25
+		Order:           28
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -655,7 +685,7 @@ Steps: {
 			CmdStr:   "go list -m -versions -retracted {{{.PROVERB}}}"
 			Negated:  false
 		}]
-		Order:           24
+		Order:           27
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -676,7 +706,7 @@ Steps: {
 			CmdStr:   "go list -m -versions {{{.PROVERB}}}"
 			Negated:  false
 		}]
-		Order:           23
+		Order:           26
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -691,7 +721,7 @@ Steps: {
 			CmdStr:           "sleep 1m"
 			Negated:          false
 		}]
-		Order:           22
+		Order:           25
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -712,7 +742,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           21
+		Order:           24
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -739,12 +769,27 @@ Steps: {
 			CmdStr:   "go get {{{.PROVERB}}}@v0.3.0"
 			Negated:  false
 		}]
-		Order:           20
+		Order:           23
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "gopher_use_v030"
+	}
+	proverb_check_v030_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           22
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "proverb_check_v030_porcelain"
 	}
 	proverb_tag_v030: {
 		Stmts: [{
@@ -794,7 +839,7 @@ Steps: {
 			CmdStr:   "git push -q origin v0.3.0"
 			Negated:  false
 		}]
-		Order:           19
+		Order:           21
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -802,7 +847,7 @@ Steps: {
 		Name:            "proverb_tag_v030"
 	}
 	proverb_go_fix_concurrency_bug: {
-		Order: 18
+		Order: 20
 		Source: """
 			package proverb
 
@@ -831,7 +876,7 @@ Steps: {
 		Name:     "proverb_go_fix_concurrency_bug"
 	}
 	proverb_comment_retraction: {
-		Order: 17
+		Order: 19
 		Source: """
 			module {{{.PROVERB}}}
 
@@ -872,7 +917,7 @@ Steps: {
 			CmdStr:   "cat go.mod"
 			Negated:  false
 		}]
-		Order:           16
+		Order:           18
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -887,7 +932,7 @@ Steps: {
 			CmdStr:           "go mod edit -retract=v0.2.0"
 			Negated:          false
 		}]
-		Order:           15
+		Order:           17
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -902,7 +947,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/proverb"
 			Negated:          false
 		}]
-		Order:           14
+		Order:           16
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -941,7 +986,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           13
+		Order:           15
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -970,12 +1015,27 @@ Steps: {
 			CmdStr:   "git push -q origin v0.2.0"
 			Negated:  false
 		}]
-		Order:           12
+		Order:           14
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "proverb_tag_v020"
+	}
+	proverb_check_concurrency_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           13
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "proverb_check_concurrency_porcelain"
 	}
 	proverb_concurrency_commit: {
 		Stmts: [{
@@ -1005,7 +1065,7 @@ Steps: {
 			CmdStr:   "git push -q origin main"
 			Negated:  false
 		}]
-		Order:           11
+		Order:           12
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1013,7 +1073,7 @@ Steps: {
 		Name:            "proverb_concurrency_commit"
 	}
 	proverb_go_concurrency: {
-		Order: 10
+		Order: 11
 		Source: """
 			package proverb
 
@@ -1049,7 +1109,7 @@ Steps: {
 			CmdStr:           "cd /home/gopher/proverb"
 			Negated:          false
 		}]
-		Order:           9
+		Order:           10
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1070,7 +1130,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           8
+		Order:           9
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1091,7 +1151,7 @@ Steps: {
 			CmdStr:   "go get {{{.PROVERB}}}@v0.1.0"
 			Negated:  false
 		}]
-		Order:           7
+		Order:           8
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1099,7 +1159,7 @@ Steps: {
 		Name:            "gopher_add_dep_proverb_v010"
 	}
 	gopher_go_initial: {
-		Order: 6
+		Order: 7
 		Source: """
 			package main
 
@@ -1149,7 +1209,7 @@ Steps: {
 			CmdStr:   "go mod init gopher"
 			Negated:  false
 		}]
-		Order:           5
+		Order:           6
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -1178,12 +1238,27 @@ Steps: {
 			CmdStr:   "git push -q origin v0.1.0"
 			Negated:  false
 		}]
-		Order:           4
+		Order:           5
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "proverb_tag_v010"
+	}
+	proverb_check_initial_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           4
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "proverb_check_initial_porcelain"
 	}
 	proverb_initial_commit: {
 		Stmts: [{
@@ -1307,5 +1382,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "796d275e2f3e824ad23d4202962fab23f95fbc0eb211b886ce9bca904d8baf9f"
+Hash: "e36bea24accec0d78bcb20aba4528ea785ef6a3533677ea86ba33051fbcd92fe"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
+++ b/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
@@ -19,6 +19,7 @@ $ git commit -q -m 'Initial commit of public module'
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ mkdir /home/gopher/private
 $ cd /home/gopher/private
 $ go mod init {{{.PRIVATE}}}
@@ -38,6 +39,7 @@ $ git commit -q -m 'Initial commit of private module'
 $ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ mkdir /home/gopher/gopher
 $ cd /home/gopher/gopher
 $ go mod init gopher

--- a/guides/2020-11-12-working-with-private-modules/guide.cue
+++ b/guides/2020-11-12-working-with-private-modules/guide.cue
@@ -82,6 +82,13 @@ Steps: public_initial_commit: preguide.#Command & {
 		"""
 }
 
+Steps: public_check_initial_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
 Steps: private_init: preguide.#Command & {
 	Source: """
 		mkdir \(Defs.private_dir)
@@ -109,6 +116,13 @@ Steps: private_initial_commit: preguide.#Command & {
 		\(Defs.git.add) \(Defs.private_go) go.mod
 		\(Defs.git.commit) -m 'Initial commit of \(Defs.private) module'
 		\(Defs.git.push) origin main
+		"""
+}
+
+Steps: private_check_initial_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -145,7 +145,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           22
+		Order:           24
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -166,7 +166,7 @@ Steps: {
 			CmdStr:   "go list -m -f {{.Version}} {{{.PRIVATE}}}"
 			Negated:  false
 		}]
-		Order:           21
+		Order:           23
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -190,7 +190,7 @@ Steps: {
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			Negated:  false
 		}]
-		Order:           20
+		Order:           22
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -205,7 +205,7 @@ Steps: {
 			CmdStr:           "go env -w GOPRIVATE={{{.PRIVATE}}}"
 			Negated:          false
 		}]
-		Order:           19
+		Order:           21
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -234,7 +234,7 @@ Steps: {
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			Negated:  true
 		}]
-		Order:           17
+		Order:           19
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -249,7 +249,7 @@ Steps: {
 			CmdStr:           "go env -w GOPROXY="
 			Negated:          false
 		}]
-		Order:           16
+		Order:           18
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -280,7 +280,7 @@ Steps: {
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			Negated:  true
 		}]
-		Order:           15
+		Order:           17
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -301,7 +301,7 @@ Steps: {
 			CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
 			Negated:  false
 		}]
-		Order:           14
+		Order:           16
 		InformationOnly: true
 		DoNotTrim:       false
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
@@ -325,7 +325,7 @@ Steps: {
 			CmdStr:   "go get {{{.PUBLIC}}}"
 			Negated:  false
 		}]
-		Order:           13
+		Order:           15
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -340,7 +340,7 @@ Steps: {
 			CmdStr:           "go env -w GOPROXY=https://proxy.golang.org"
 			Negated:          false
 		}]
-		Order:           12
+		Order:           14
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -401,7 +401,7 @@ Steps: {
 			CmdStr:   "go help env"
 			Negated:  false
 		}]
-		Order:           11
+		Order:           13
 		InformationOnly: true
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -422,7 +422,7 @@ Steps: {
 			CmdStr:   "go env GOSUMDB"
 			Negated:  false
 		}]
-		Order:           10
+		Order:           12
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -443,12 +443,39 @@ Steps: {
 			CmdStr:   "go env GOPROXY"
 			Negated:  false
 		}]
-		Order:           9
+		Order:           11
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "go_env_check_goproxy"
+	}
+	gopher_go_initial: {
+		Order: 10
+		Source: """
+			package main
+
+			import (
+			\t"fmt"
+
+			\t"{{{.PUBLIC}}}"
+			\t"{{{.PRIVATE}}}"
+			)
+
+			func main() {
+			\tfmt.Printf("public.Message(): %v\\n", public.Message())
+			\tfmt.Printf("private.Secret(): %v\\n", private.Secret())
+			}
+
+			"""
+		Renderer: {
+			RendererType: 1
+		}
+		Language: "go"
+		Target:   "/home/gopher/gopher/gopher.go"
+		Terminal: "term1"
+		StepType: 2
+		Name:     "gopher_go_initial"
 	}
 	gopher_init: {
 		Stmts: [{
@@ -476,12 +503,27 @@ Steps: {
 			CmdStr:   "go mod init gopher"
 			Negated:  false
 		}]
-		Order:           7
+		Order:           9
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "gopher_init"
+	}
+	private_check_initial_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           8
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "private_check_initial_porcelain"
 	}
 	private_initial_commit: {
 		Stmts: [{
@@ -511,7 +553,7 @@ Steps: {
 			CmdStr:   "git push -q origin main"
 			Negated:  false
 		}]
-		Order:           6
+		Order:           7
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -519,7 +561,7 @@ Steps: {
 		Name:            "private_initial_commit"
 	}
 	private_go_initial: {
-		Order: 5
+		Order: 6
 		Source: """
 			package private
 
@@ -575,12 +617,27 @@ Steps: {
 			CmdStr:           "git remote add origin https://{{{.PRIVATE}}}.git"
 			Negated:          false
 		}]
-		Order:           4
+		Order:           5
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "private_init"
+	}
+	public_check_initial_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           4
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "public_check_initial_porcelain"
 	}
 	public_initial_commit: {
 		Stmts: [{
@@ -681,6 +738,27 @@ Steps: {
 		StepType:        1
 		Name:            "public_init"
 	}
+	goversion: {
+		Stmts: [{
+			ComparisonOutput: """
+				go version go1.15.5 linux/amd64
+
+				"""
+			Output: """
+				go version go1.15.5 linux/amd64
+
+				"""
+			ExitCode: 0
+			CmdStr:   "go version"
+			Negated:  false
+		}]
+		Order:           0
+		InformationOnly: false
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "goversion"
+	}
 	go_help_modprivate: {
 		Stmts: [{
 			ComparisonOutput: """
@@ -775,61 +853,13 @@ Steps: {
 			CmdStr:   "go help module-private"
 			Negated:  false
 		}]
-		Order:           18
+		Order:           20
 		InformationOnly: true
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "go_help_modprivate"
 	}
-	gopher_go_initial: {
-		Order: 8
-		Source: """
-			package main
-
-			import (
-			\t"fmt"
-
-			\t"{{{.PUBLIC}}}"
-			\t"{{{.PRIVATE}}}"
-			)
-
-			func main() {
-			\tfmt.Printf("public.Message(): %v\\n", public.Message())
-			\tfmt.Printf("private.Secret(): %v\\n", private.Secret())
-			}
-
-			"""
-		Renderer: {
-			RendererType: 1
-		}
-		Language: "go"
-		Target:   "/home/gopher/gopher/gopher.go"
-		Terminal: "term1"
-		StepType: 2
-		Name:     "gopher_go_initial"
-	}
-	goversion: {
-		Stmts: [{
-			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
-
-				"""
-			Output: """
-				go version go1.15.5 linux/amd64
-
-				"""
-			ExitCode: 0
-			CmdStr:   "go version"
-			Negated:  false
-		}]
-		Order:           0
-		InformationOnly: false
-		DoNotTrim:       false
-		Terminal:        "term1"
-		StepType:        1
-		Name:            "goversion"
-	}
 }
-Hash: "ed339105de4ec3c3cc8979d4f4ec5ddb598fd7e8f7f6a6650d0b9c6fe347d987"
+Hash: "4e123ad2f4678f98223cb3f582ad168816ed7b3e9f5d3626629770544a23b2d4"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
+++ b/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
@@ -20,6 +20,7 @@ $ git tag v1.0.0
 $ git push -q origin main v1.0.0
 remote: .. Processing 2 references        
 remote: Processed 2 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ git branch main.v1
 $ git push -q origin main.v1
 remote: 
@@ -50,6 +51,7 @@ $ git tag v2.0.0
 $ git push -q origin main v2.0.0
 remote: .. Processing 2 references        
 remote: Processed 2 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ mkdir /home/gopher/subdir
 $ cd /home/gopher/subdir
 $ go mod init {{{.SUBDIR}}}
@@ -70,6 +72,7 @@ $ git tag v1.0.0
 $ git push -q origin main v1.0.0
 remote: .. Processing 2 references        
 remote: Processed 2 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ mkdir v2
 $ cp go.mod subdir.go v2
 $ cat <<EOD > /home/gopher/subdir/v2/go.mod
@@ -94,6 +97,7 @@ $ git tag v2.0.0
 $ git push -q origin main v2.0.0
 remote: .. Processing 2 references        
 remote: Processed 2 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ mkdir /home/gopher/gopher
 $ cd /home/gopher/gopher
 $ go mod init gopher

--- a/guides/2020-11-19-major-version-repository-structure/guide.cue
+++ b/guides/2020-11-19-major-version-repository-structure/guide.cue
@@ -81,6 +81,13 @@ Steps: branch_initial_commit: preguide.#Command & {
 		"""
 }
 
+Steps: branch_check_initial_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
 Steps: branch_create_v1_branch: preguide.#Command & {
 	Source: """
 		\(Defs.git.branch) main.v1
@@ -121,6 +128,13 @@ Steps: branch_v2_commit: preguide.#Command & {
 		"""
 }
 
+Steps: branch_check_v2_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
 Steps: subdir_init: preguide.#Command & {
 	Source: """
 		mkdir \(Defs.subdir_dir)
@@ -149,6 +163,13 @@ Steps: subdir_initial_commit: preguide.#Command & {
 		\(Defs.git.commit) -m 'Initial commit of \(Defs.subdir) module'
 		\(Defs.git.tag) v1.0.0
 		\(Defs.git.push) origin main v1.0.0
+		"""
+}
+
+Steps: subdir_check_initial_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 
@@ -189,6 +210,13 @@ Steps: subdir_v2_commit: preguide.#Command & {
 		\(Defs.git.commit) -m 'v2 commit of \(Defs.subdir) module'
 		\(Defs.git.tag) v2.0.0
 		\(Defs.git.push) origin main v2.0.0
+		"""
+}
+
+Steps: subdir_check_v2_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
 		"""
 }
 

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -149,7 +149,7 @@ Steps: {
 			CmdStr:   "go run ."
 			Negated:  false
 		}]
-		Order:           18
+		Order:           22
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -206,7 +206,7 @@ Steps: {
 			CmdStr:   "go get {{{.SUBDIR}}}/v2@v2.0.0"
 			Negated:  false
 		}]
-		Order:           17
+		Order:           21
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -214,7 +214,7 @@ Steps: {
 		Name:            "gopher_get_deps"
 	}
 	gopher_go_initial: {
-		Order: 16
+		Order: 20
 		Source: """
 			// /home/gopher/gopher/gopher.go
 
@@ -272,12 +272,27 @@ Steps: {
 			CmdStr:   "go mod init gopher"
 			Negated:  false
 		}]
-		Order:           15
+		Order:           19
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "gopher_init"
+	}
+	subdir_check_v2_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           18
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "subdir_check_v2_porcelain"
 	}
 	subdir_v2_commit: {
 		Stmts: [{
@@ -313,7 +328,7 @@ Steps: {
 			CmdStr:   "git push -q origin main v2.0.0"
 			Negated:  false
 		}]
-		Order:           14
+		Order:           17
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -321,7 +336,7 @@ Steps: {
 		Name:            "subdir_v2_commit"
 	}
 	subdir_go_v2: {
-		Order: 13
+		Order: 16
 		Source: """
 			// /home/gopher/subdir/v2/subdir.go
 
@@ -331,15 +346,7 @@ Steps: {
 
 			"""
 		Renderer: {
-			Pre: """
-				// /home/gopher/subdir/subdir.go
-
-				package subdir
-
-				const Message = "subdir v1"
-
-				"""
-			RendererType: 3
+			RendererType: 1
 		}
 		Language: "go"
 		Target:   "/home/gopher/subdir/v2/subdir.go"
@@ -348,7 +355,7 @@ Steps: {
 		Name:     "subdir_go_v2"
 	}
 	subdir_go_mod_v2: {
-		Order: 12
+		Order: 15
 		Source: """
 			// /home/gopher/subdir/v2/go.mod
 
@@ -380,12 +387,27 @@ Steps: {
 			CmdStr:           "cp go.mod subdir.go v2"
 			Negated:          false
 		}]
-		Order:           11
+		Order:           14
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "subdir_create_v2_subdir"
+	}
+	subdir_check_initial_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           13
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "subdir_check_initial_porcelain"
 	}
 	subdir_initial_commit: {
 		Stmts: [{
@@ -421,7 +443,7 @@ Steps: {
 			CmdStr:   "git push -q origin main v1.0.0"
 			Negated:  false
 		}]
-		Order:           10
+		Order:           12
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -429,7 +451,7 @@ Steps: {
 		Name:            "subdir_initial_commit"
 	}
 	subdir_go_initial: {
-		Order: 9
+		Order: 11
 		Source: """
 			// /home/gopher/subdir/subdir.go
 
@@ -485,12 +507,27 @@ Steps: {
 			CmdStr:           "git remote add origin https://{{{.SUBDIR}}}.git"
 			Negated:          false
 		}]
-		Order:           8
+		Order:           10
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "subdir_init"
+	}
+	branch_check_v2_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           9
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "branch_check_v2_porcelain"
 	}
 	branch_v2_commit: {
 		Stmts: [{
@@ -526,7 +563,7 @@ Steps: {
 			CmdStr:   "git push -q origin main v2.0.0"
 			Negated:  false
 		}]
-		Order:           7
+		Order:           8
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
@@ -534,7 +571,7 @@ Steps: {
 		Name:            "branch_v2_commit"
 	}
 	branch_go_v2: {
-		Order: 6
+		Order: 7
 		Source: """
 			// /home/gopher/branch/branch.go
 
@@ -544,15 +581,7 @@ Steps: {
 
 			"""
 		Renderer: {
-			Pre: """
-				// /home/gopher/branch/branch.go
-
-				package branch
-
-				const Message = "branch v1"
-
-				"""
-			RendererType: 3
+			RendererType: 1
 		}
 		Language: "go"
 		Target:   "/home/gopher/branch/branch.go"
@@ -561,7 +590,7 @@ Steps: {
 		Name:     "branch_go_v2"
 	}
 	branch_go_mod_v2: {
-		Order: 5
+		Order: 6
 		Source: """
 			// /home/gopher/branch/go.mod
 
@@ -609,12 +638,27 @@ Steps: {
 			CmdStr:   "git push -q origin main.v1"
 			Negated:  false
 		}]
-		Order:           4
+		Order:           5
 		InformationOnly: false
 		DoNotTrim:       false
 		Terminal:        "term1"
 		StepType:        1
 		Name:            "branch_create_v1_branch"
+	}
+	branch_check_initial_porcelain: {
+		Stmts: [{
+			ComparisonOutput: ""
+			Output:           ""
+			ExitCode:         0
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			Negated:          false
+		}]
+		Order:           4
+		InformationOnly: true
+		DoNotTrim:       false
+		Terminal:        "term1"
+		StepType:        1
+		Name:            "branch_check_initial_porcelain"
 	}
 	branch_initial_commit: {
 		Stmts: [{
@@ -743,5 +787,5 @@ Steps: {
 		Name:            "goversion"
 	}
 }
-Hash: "5e79c75bc1c0ac090da76b2cc7da8bda2cfd00ed65227a0324a129a44d5d772e"
+Hash: "1f6ace51229a5fb4060202db5d821f811a2108e9c03c4a3a07ccf4051a72f675"
 Delims: ["{{{", "}}}"]


### PR DESCRIPTION
This will automated at a later stage by play-with-go/preguide#153 (or
indeed by guides which are more verbose in their explanation to use,
e.g. running a git status after a git commit to show the state is
"clean") but for now add InformationOnly steps that verify we have a
clean working tree after creating a commit.

Fix a couple of instances where that was not the case.