### PR TITLE
Replate "Github" with "GitHub" on the top page

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ layout: plain
             <div class="col-xs">
             <button onclick="performLogin('github')" class="btn np-login btn-primary btn-welcome">
               <img src="{{site.baseurl}}/images/github.svg" alt="Text"/>
-              <span>Sign-in with Github</span>
+              <span>Sign-in with GitHub</span>
               </button>
             </div>
             </div>


### PR DESCRIPTION
Hello, this is just a small fix. This fixes the case of "Github" to "GitHub" on the landing page.

I searched all the files and there is no other "Github".

**Screenshot after the change**

![](https://user-images.githubusercontent.com/1425259/100044270-995ae900-2e52-11eb-97dc-10af8f58d6b9.png)