### PR TITLE
guides: make installing-go-programs-directly reproducible

### DIFF
--- a/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
+++ b/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
@@ -39,7 +39,7 @@ go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
 Currently, tool authors who want to provide installation instructions in their projects' `README.md` typically include:
 
 ```.term1
-$ go get filippo.io/mkcert
+$ go get filippo.io/mkcert@v1.4.2
 go: downloading filippo.io/mkcert v1.4.2
 go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
@@ -49,7 +49,11 @@ go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f
 go: downloading golang.org/x/text v0.3.0
 go: downloading github.com/BurntSushi/toml v0.3.1
 ```
-{:data-command-src="Z28gZ2V0IGZpbGlwcG8uaW8vbWtjZXJ0Cg=="}
+{:data-command-src="Z28gZ2V0IGZpbGlwcG8uaW8vbWtjZXJ0QHYxLjQuMgo="}
+
+_Note: most `README.md` instructions that use `go get` do not specify a version. This results in the latest
+version of a package being fetched. A specific version, `v1.4.2`, is used here to ensure this guide
+remains reproducible._
 
 There are a number of problems with this approach:
 

--- a/_scripts/generateGuides.sh
+++ b/_scripts/generateGuides.sh
@@ -13,12 +13,4 @@ then
 	export PREGUIDE_SKIP_CACHE=true
 fi
 
-function join_by { local d=$1; shift; local f=$1; shift; printf %s "$f" "${@/#/$d}"; }
-
-run=""
-if [ "$#" != "0" ]
-then
-	export PREGUIDE_RUN="$(join_by '|' "$@")"
-fi
-
 go generate -tags guides ./guides

--- a/guides/2020-11-09-installing-go-programs-directly/en.markdown
+++ b/guides/2020-11-09-installing-go-programs-directly/en.markdown
@@ -34,6 +34,10 @@ Currently, tool authors who want to provide installation instructions in their p
 
 {{{ step "go115_mkcert_get" }}}
 
+_Note: most `README.md` instructions that use `{{{ .cmdgo.get }}}` do not specify a version. This results in the latest
+version of a package being fetched. A specific version, `{{{.mkcert_version}}}`, is used here to ensure this guide
+remains reproducible._
+
 There are a number of problems with this approach:
 
 * A user might run the above `{{{ .cmdgo.get }}}` within a module, which would

--- a/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
+++ b/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
@@ -1,6 +1,6 @@
 $ go version
 go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
-$ go get filippo.io/mkcert
+$ go get filippo.io/mkcert@v1.4.2
 go: downloading filippo.io/mkcert v1.4.2
 go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11

--- a/guides/2020-11-09-installing-go-programs-directly/guide.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/guide.cue
@@ -29,7 +29,7 @@ Steps: goversion: preguide.#Command & {
 
 Steps: go115_mkcert_get: preguide.#Command & {
 	Source: """
-		go get \(Defs.mkcert_pkg)
+		go get \(Defs.mkcert_pkg)@\(Defs.mkcert_version)
 		"""
 }
 

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -62,7 +62,7 @@ Steps: {
 
 				"""
 			ExitCode: 0
-			CmdStr:   "go get filippo.io/mkcert"
+			CmdStr:   "go get filippo.io/mkcert@v1.4.2"
 			Negated:  false
 		}]
 		Order:           1
@@ -176,5 +176,5 @@ Steps: {
 		Name:            "goversion_mkcert"
 	}
 }
-Hash: "f824051f1210794edf43a5d84cd61d8559f382f150540111ed0c7c50100df97b"
+Hash: "1739e133d061bb8431773e7d302071e5ce59745763f6bca5732fe1a1284d3c64"
 Delims: ["{{{", "}}}"]


### PR DESCRIPTION
Specify the version of mkcert we want to go get; add a comment
explaining why we need to do that.