### PR TITLE
deps: latest preguide; can comment file blocks with target location

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -760,7 +760,7 @@ $ go test -v
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.003s
 </code></pre>
 
 You will now break the `greetings.Hello` function to view a failing test. The `TestHelloName` test function

--- a/cue.mod/pkg/github.com/play-with-go/preguide/out/out.cue
+++ b/cue.mod/pkg/github.com/play-with-go/preguide/out/out.cue
@@ -4,6 +4,7 @@ import "github.com/play-with-go/preguide"
 
 #GuideOutput: {
 	Delims: [string, string]
+	FilenameComment: bool
 	Presteps: [...#Prestep]
 	Terminals: [...preguide.#Terminal]
 	Scenarios: [...preguide.#Scenario]

--- a/cue.mod/pkg/github.com/play-with-go/preguide/preguide.cue
+++ b/cue.mod/pkg/github.com/play-with-go/preguide/preguide.cue
@@ -25,6 +25,8 @@ import (
 		Terminal: string
 	}
 
+	FilenameComment: *false | bool
+
 	_#stepCommon: {
 		Name:     string
 		StepType: #StepType

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
 	github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e0
 	github.com/play-with-go/gitea v0.0.0-20201117212359-e8c942fd23b1
-	github.com/play-with-go/preguide v0.0.2-0.20201127055619-8777d2847809
+	github.com/play-with-go/preguide v0.0.2-0.20201127063021-618bc89b79b5
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 )

--- a/go.sum
+++ b/go.sum
@@ -425,8 +425,8 @@ github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e
 github.com/play-with-go/gitea v0.0.0-20201117212359-e8c942fd23b1 h1:GF1ytqY5ImU/VwbxBRfry/sOIsXpZWwxUM50WNRySeo=
 github.com/play-with-go/gitea v0.0.0-20201117212359-e8c942fd23b1/go.mod h1:u2EwEyaJW1TLsVERI3nAQHW6k/N1tBGvuI9jT9q5lP0=
 github.com/play-with-go/preguide v0.0.2-0.20200929132054-e0f48a7f7b23/go.mod h1:jkhBBbIBioAzKiRo5Rr9r03tqglgUdPZAVIpBBw7aDU=
-github.com/play-with-go/preguide v0.0.2-0.20201127055619-8777d2847809 h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=
-github.com/play-with-go/preguide v0.0.2-0.20201127055619-8777d2847809/go.mod h1:BP/erWoHufPAH3N3LELZp4/h2AIvnDSKbsszy+bqgmM=
+github.com/play-with-go/preguide v0.0.2-0.20201127063021-618bc89b79b5 h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=
+github.com/play-with-go/preguide v0.0.2-0.20201127063021-618bc89b79b5/go.mod h1:BP/erWoHufPAH3N3LELZp4/h2AIvnDSKbsszy+bqgmM=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/guides/2018-10-19-go-fundamentals/go115_en_log.txt
+++ b/guides/2018-10-19-go-fundamentals/go115_en_log.txt
@@ -392,7 +392,7 @@ $ go test -v
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	{{{.GREETINGS}}}	0.002s
+ok  	{{{.GREETINGS}}}	0.003s
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -128,6 +128,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -1541,7 +1542,7 @@ Steps: {
 				=== RUN   TestHelloEmpty
 				--- PASS: TestHelloEmpty (0.00s)
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.002s
+				ok  \t{{{.GREETINGS}}}\t0.003s
 
 				"""
 			ExitCode: 0
@@ -1989,5 +1990,5 @@ Steps: {
 		Name:            "hello_run_by_name"
 	}
 }
-Hash: "22e5b03d5996f0b417213d75feaf21af18998a008ac6ff4c495476549c19cd63"
+Hash: "e9624b44cc03ef376d7f76d9e5f7babcd663f2f8d71ab62a5fe3b5c618c508d5"
 Delims: ["{{{", "}}}"]

--- a/guides/2019-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2019-10-15-get-started-with-go/out/gen_out.cue
@@ -15,6 +15,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -222,5 +223,5 @@ Steps: {
 		Name:            "run_hello_again"
 	}
 }
-Hash: "f209986eb24e8efc42c862a7a5e028d0a7d95a895d49532c48d784493a59d20c"
+Hash: "eb95610716bc610fcde40619d5a1972244f258077fe1811c5254463be3540c61"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-08-13-installing-go/out/gen_out.cue
+++ b/guides/2020-08-13-installing-go/out/gen_out.cue
@@ -15,6 +15,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	start_dir: {
 		Stmts: [{
@@ -453,5 +454,5 @@ Steps: {
 		Name:            "echo_path"
 	}
 }
-Hash: "f73b2e3c09c903e88442b6261a9eb23006cbb53163b44a8778693dc39e1ce6a9"
+Hash: "acadb0ef73de450e9efc712093e905fd88e016f1a20e075f14f6d26c76fcae16"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -124,6 +124,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	create_module: {
 		Stmts: [{
@@ -335,5 +336,5 @@ Steps: {
 		Name:            "mod1_pseudoversion"
 	}
 }
-Hash: "b2e486dd84e74881a8d51d333549ab6dbf00e506e57fcc62ab0fee67bdd2bbc5"
+Hash: "65394bbe4ff91387360dc29d68c24bc3fc84411ea8dd8ee0e5c44f0ff5efa775"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -124,6 +124,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	whoami: {
 		Stmts: [{
@@ -339,5 +340,5 @@ Steps: {
 		Name:            "gitpush"
 	}
 }
-Hash: "7f6ae4cca60e27970520e586f919bd69132a02dcafeddf71530ce3db30758dba"
+Hash: "f428b1ca5d2429e2fc66cbe16375ae69b104a0206657058bd61215ff9be51940"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -124,6 +124,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -780,5 +781,5 @@ Steps: {
 		Name:            "painkiller_check_fever_advice"
 	}
 }
-Hash: "2052857141c6a876a0e2160c5a9b3dd97f69583b6ffa68928a5759ad144fcbb3"
+Hash: "50577c8ee2d73ac731c10cc6955a3243380353c3a395b95417c842099bb619c2"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -124,6 +124,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -1382,5 +1383,5 @@ Steps: {
 		Name:            "gopher_run_life_proverb"
 	}
 }
-Hash: "9bd2a732fa03ae36178e6a5645af4a5db233eeb35cf00accf6a37ba21e071041"
+Hash: "046a3276da5f2e431b3adee33b32adee0a509592eda843975d4bbb62e95b98d9"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -15,6 +15,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -176,5 +177,5 @@ Steps: {
 		Name:            "goversion_mkcert"
 	}
 }
-Hash: "9ea49ee3b141a06c9945fd37de54c955d45a74b4b078310c12c2cc351d65956a"
+Hash: "5b876f360f6ebd1cb190158cb9df035ef905538f4321ef3c10ca1860f529d844"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -15,6 +15,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -915,5 +916,5 @@ Steps: {
 		Name:            "pets_staticcheck_final"
 	}
 }
-Hash: "d873acc14957482352f68b4b861e6cf69c88b5cf3c706d57eff0406fe3e91b70"
+Hash: "425d248d2ccc27072ce59eeb01949201a472566c7bb38729f3329b99b40bd25c"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -128,6 +128,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -861,5 +862,5 @@ Steps: {
 		Name:            "gopher_run"
 	}
 }
-Hash: "ee1ae68ae10b43533ac6fa1e5a38bf8e68f94213417c141caf9058a103bc9a9a"
+Hash: "e4cb8f3830d86416838afc897d487876948216d1f8f221696b039879999ea627"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -56,8 +56,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20201127055619-8777d2847809",
-		      "Sum": "h1:AFGAfyRMZ71UMh26WqlC1eWG379ulXpMZD357jL0tVk=",
+		      "Version": "v0.0.2-0.20201127063021-618bc89b79b5",
+		      "Sum": "h1:D8LWv2UGZd6JG8fIg1ASdBr0K7gLhthZ0UcBmGNbI4A=",
 		      "Replace": null
 		    },
 		    {
@@ -128,6 +128,7 @@ Scenarios: [{
 }]
 Networks: ["playwithgo_pwg"]
 Env: []
+FilenameComment: false
 Steps: {
 	goversion: {
 		Stmts: [{
@@ -787,5 +788,5 @@ Steps: {
 		Name:            "gopher_run"
 	}
 }
-Hash: "a2f223c85a2ae39aa8086c9704b61e91e9e12b66f470217048c051772f6b1d1d"
+Hash: "600fd67da6b249092d685e4fa279878ef92a9c54951a56bf8abf5ef5ecf17ba9"
 Delims: ["{{{", "}}}"]


### PR DESCRIPTION
This is not on for now, but can be turned on for individual guides or
all of them.