### PR TITLE
ci: optimise Dockerfile's used as part of compose setup

### DIFF
--- a/docker/cmd_gitea/Dockerfile
+++ b/docker/cmd_gitea/Dockerfile
@@ -8,7 +8,7 @@ ENV GOMODCACHE=/root/.cache/go/gomodcache
 ENV CGO_ENABLED=0
 ENV GOPATH=
 
-COPY . .
+COPY go.mod go.sum .
 
 RUN --mount=type=cache,target=/root/.cache/go go build github.com/play-with-go/gitea/cmd/gitea
 

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -8,7 +8,8 @@ ENV GOMODCACHE=/root/.cache/go/gomodcache
 ENV CGO_ENABLED=0
 ENV GOPATH=
 
-COPY . .
+COPY go.mod go.sum .
+COPY cmd/ ./cmd
 
 RUN --mount=type=cache,target=/root/.cache/go go build -o cmd/controller/controller ./cmd/controller
 

--- a/docker/l2/Dockerfile
+++ b/docker/l2/Dockerfile
@@ -8,7 +8,7 @@ ENV GOMODCACHE=/root/.cache/go/gomodcache
 ENV CGO_ENABLED=0
 ENV GOPATH=
 
-COPY . .
+COPY go.mod go.sum .
 
 RUN --mount=type=cache,target=/root/.cache/go go build github.com/play-with-docker/play-with-docker/router/l2
 

--- a/docker/pwd/Dockerfile
+++ b/docker/pwd/Dockerfile
@@ -8,7 +8,7 @@ ENV GOMODCACHE=/root/.cache/go/gomodcache
 ENV CGO_ENABLED=0
 ENV GOPATH=
 
-COPY . .
+COPY go.mod go.sum .
 
 RUN --mount=type=cache,target=/root/.cache/go go build github.com/play-with-docker/play-with-docker
 


### PR DESCRIPTION
We don't need to copy the entire of the PWG directory in most cases.
Doing so also invalidates the build unnecessarily, because buildkit
can't know/work out that a build is not required