### PR TITLE
guides: use latest docker images for improved prompt

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -753,14 +753,14 @@ The tests should pass:
 
 <pre data-command-src="Z28gdGVzdApnbyB0ZXN0IC12Cg=="><code class="language-.term1">$ go test
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.003s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.003s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
 </code></pre>
 
 You will now break the `greetings.Hello` function to view a failing test. The `TestHelloName` test function

--- a/guides/2018-10-19-go-fundamentals/go115_en_log.txt
+++ b/guides/2018-10-19-go-fundamentals/go115_en_log.txt
@@ -385,14 +385,14 @@ func TestHelloEmpty(t *testing.T) {
 EOD
 $ go test
 PASS
-ok  	{{{.GREETINGS}}}	0.002s
+ok  	{{{.GREETINGS}}}	0.003s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	{{{.GREETINGS}}}	0.003s
+ok  	{{{.GREETINGS}}}	0.002s
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -1524,7 +1524,7 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.002s
+				ok  \t{{{.GREETINGS}}}\t0.003s
 
 				"""
 			ComparisonOutput: """
@@ -1542,7 +1542,7 @@ Steps: {
 				=== RUN   TestHelloEmpty
 				--- PASS: TestHelloEmpty (0.00s)
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.003s
+				ok  \t{{{.GREETINGS}}}\t0.002s
 
 				"""
 			ComparisonOutput: """
@@ -1990,5 +1990,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "85e1a7a20134544bca854341e97ac6ab48dd7f7767f0fa4813e9b0e3c1206197"
+Hash: "14493470a97b2d4ba53a91c1b581926efa0373384b612a26b368779eb72a34fb"
 Delims: ["{{{", "}}}"]

--- a/guides/2019-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2019-10-15-get-started-with-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -223,5 +223,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "f84600efdfca285c26efcb59e2bf4c6ba73748c82ae73db75ec4d9a71f4a4c6c"
+Hash: "5f6a7cdc81b60b64e3564037d445396342c207edef73a366f38bd1e72e00d12e"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-08-13-installing-go/out/gen_out.cue
+++ b/guides/2020-08-13-installing-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/installgo1.15.5@sha256:549ca296f74aab093428a0a8b283f9d7d6c0a8390af7fd33129bbdb983c461ba"
+			Image: "playwithgo/installgo1.15.5@sha256:e1feb9c08fc4a728a9eb04651b8c2fd44c79b7f2278de83bb4a7598a57301576"
 		}
 	}
 }]
@@ -454,5 +454,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "57a5c926ebf077cbda9bbefc96578d259619ecc7248cd535b26b140af0d317dd"
+Hash: "eeb26d6eabd546020b6f237bc95884236eee5d09b2f597415068f409206bdbb9"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -336,5 +336,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "6dae6cc137006281bdb78c5857a7146e5f8614398e177e1d470f88d763337940"
+Hash: "0f98a5deb31efe48aa28d6b207b07fd8ba23fdf8c1ba991cbcd85b151c5cca62"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -340,5 +340,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "0bc3272b09f08e8f15d367df1493b72185568f4c57c99c081093a7882971f4fe"
+Hash: "51b3ba95e014f99bc5b776961595ca797a7d4cd3503076901a39d46fa5b6deb4"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -781,5 +781,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "14a7900b97614ab637e04172c750aded1d82e6f002b6b9772d849415f52e1e6d"
+Hash: "241cc5e1590edf87cf72f75d2f2d7eb134f8308d4c38d5e09e9d20690e95347e"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16-tip@sha256:af9da82837751157485d9c2008b4ad950037502d9d18715cb1e617f4b2d6f169"
+			Image: "playwithgo/go1.16-tip@sha256:eb14debbd59bb5b4252d4026780a0469fdda7601cdcfd1aa4c0ea685881cea28"
 		}
 	}
 }]
@@ -1383,5 +1383,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "87d884ec82f3351831926578efe25bbdacf9b0f7f4b964f658f48791fe9c968d"
+Hash: "5849bb2686bb0379a7e2a4347b92da8e780337194d8ee8b643f2a13add4e0bb9"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16-tip@sha256:af9da82837751157485d9c2008b4ad950037502d9d18715cb1e617f4b2d6f169"
+			Image: "playwithgo/go1.16-tip@sha256:eb14debbd59bb5b4252d4026780a0469fdda7601cdcfd1aa4c0ea685881cea28"
 		}
 	}
 }]
@@ -177,5 +177,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "c87ca51af3d5ea39e85b5fd0eff406b4be9ba99b034761c6efa0b69f20677b98"
+Hash: "13199046e3061a541c75ba65ac4ceae584a73500410781a874f672d62752a919"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -916,5 +916,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "8d4b2bf2756441d7c8a6581ce155463d2066021d68f24520ecebf0bb9674283e"
+Hash: "ebd38094c49fad82ff80b8c169a5634d0bc7ef13f56a2ce5d87a318789a9d9af"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -862,5 +862,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "365dd25ad2f88ee9d62e095f710f72403e47ea015a2437ca783b9aa4ac4469e1"
+Hash: "581d67344fcac0588c4d2aa5b2b925803d88a60cfbc61faec319464828a1dbe8"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+			Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 		}
 	}
 }]
@@ -788,5 +788,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "6f5b7964354ebd25bc16f307a7941dedb07fc6619bb52fd155ca75fa5dcd40d3"
+Hash: "563c3fdd6c44cabd98315c1cfb761b01c768acde3d4353c4b46112c4ed350231"
 Delims: ["{{{", "}}}"]

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -22,7 +22,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -40,7 +40,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -58,7 +58,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/installgo1.15.5@sha256:549ca296f74aab093428a0a8b283f9d7d6c0a8390af7fd33129bbdb983c461ba"
+				Image: "playwithgo/installgo1.15.5@sha256:e1feb9c08fc4a728a9eb04651b8c2fd44c79b7f2278de83bb4a7598a57301576"
 			}
 		}
 	}]
@@ -87,7 +87,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -116,7 +116,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -145,7 +145,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -174,7 +174,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16-tip@sha256:af9da82837751157485d9c2008b4ad950037502d9d18715cb1e617f4b2d6f169"
+				Image: "playwithgo/go1.16-tip@sha256:eb14debbd59bb5b4252d4026780a0469fdda7601cdcfd1aa4c0ea685881cea28"
 			}
 		}
 	}]
@@ -192,7 +192,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16-tip@sha256:af9da82837751157485d9c2008b4ad950037502d9d18715cb1e617f4b2d6f169"
+				Image: "playwithgo/go1.16-tip@sha256:eb14debbd59bb5b4252d4026780a0469fdda7601cdcfd1aa4c0ea685881cea28"
 			}
 		}
 	}]
@@ -210,7 +210,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -243,7 +243,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]
@@ -276,7 +276,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
+				Image: "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
 			}
 		}
 	}]

--- a/guides/guide.cue
+++ b/guides/guide.cue
@@ -10,10 +10,10 @@ Networks: *["playwithgo_pwg"] | [...string]
 
 Delims: ["{{{", "}}}"]
 
-_#installGo:          "playwithgo/installgo1.15.5@sha256:549ca296f74aab093428a0a8b283f9d7d6c0a8390af7fd33129bbdb983c461ba"
+_#installGo:          "playwithgo/installgo1.15.5@sha256:e1feb9c08fc4a728a9eb04651b8c2fd44c79b7f2278de83bb4a7598a57301576"
 _#go115LatestVersion: "go1.15.5"
-_#go115LatestImage:   "playwithgo/go1.15.5@sha256:1c332c6b4e73dee8075badc66fe23c7fe51c44ddd2becb6cffc2db81bdaa0b06"
-_#go116LatestImage:   "playwithgo/go1.16-tip@sha256:af9da82837751157485d9c2008b4ad950037502d9d18715cb1e617f4b2d6f169"
+_#go115LatestImage:   "playwithgo/go1.15.5@sha256:e26150265392c264f720f524a6402092efffca9afd475b11512afff0aa813bc6"
+_#go116LatestImage:   "playwithgo/go1.16-tip@sha256:eb14debbd59bb5b4252d4026780a0469fdda7601cdcfd1aa4c0ea685881cea28"
 
 _#golangToolsLatest: "v0.0.0-20201105220310-78b158585360"
 


### PR DESCRIPTION
This isn't perfect because we still have a hack whereby the upload of a
file is faked as a command. We should make this a proper command (as a
comment) in any case.