### PR TITLE
docker: install a specific version of jekyll-toc

### DIFF
--- a/_scripts/generateEverythingElse.sh
+++ b/_scripts/generateEverythingElse.sh
@@ -19,4 +19,8 @@ then
 	popd > /dev/null
 fi
 
+# Explicit build step because the site portion of the config is not
+# systematically rebuilt unlike the other parts of the config,
+# precisely because it is contained in a separate yaml file.
+./_scripts/dc.sh -f docker-compose.yml -f docker-compose-website.yml build site
 ./_scripts/dc.sh -f docker-compose.yml -f docker-compose-website.yml run --rm -e JEKYLL_UID=$(id -u) -e JEKYLL_GID=$(id -g) site

--- a/docker/site/Dockerfile
+++ b/docker/site/Dockerfile
@@ -1,7 +1,7 @@
 # jekyll/jekyll:3.8
 FROM jekyll/jekyll@sha256:9521c8aae4739fcbc7137ead19f91841b833d671542f13e91ca40280e88d6e34
 
-RUN gem install jekyll-toc
+RUN gem install jekyll-toc -v 0.16.1
 
 # Overwrite the entrypoint and jekyll with more sensible versions
 COPY docker/site/entrypoint /usr/jekyll/bin/entrypoint


### PR DESCRIPTION
In our base image for the site part of Docker compose, we were running:

    RUN gem install jekyll-toc

This installed the latest versio of jekyll-toc at that point in time.
Which is a) clearly not reproducible, and b) liable to be brittle in the
presence of bad new versions.

Exactly that happened this morning with the release of v0.17.0, which
started to give rise to errors reported in:

    https://github.com/toshimaru/jekyll-toc/issues/141

This change installs a specific version of that dependency to make this
more resilient.