### PR TITLE
docker: use official docker/dockerfile image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-        - 1.15.4
+        - 1.15.7
         os:
         - ubuntu-18.04
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         go_version:
-        - 1.15.4
+        - 1.15.7
         os:
         - macos-latest
     runs-on: ${{ matrix.os }}

--- a/docker/cmd_gitea/Dockerfile
+++ b/docker/cmd_gitea/Dockerfile
@@ -1,7 +1,11 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
 
-# golang:1.15.2
-FROM golang@sha256:da7ff43658854148b401f24075c0aa390e3b52187ab67cab0043f2b15e754a68 AS stage1
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
+
+# golang:1.15.7
+FROM golang@sha256:c161abf0cde3969e05f6914a86cab804b2b0df515f4ff9570475b25547ba7959 AS stage1
 
 ENV GOCACHE=/root/.cache/go/gocache
 ENV GOMODCACHE=/root/.cache/go/gomodcache

--- a/docker/controller/Dockerfile
+++ b/docker/controller/Dockerfile
@@ -1,7 +1,11 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
 
-# golang:1.15.2
-FROM golang@sha256:da7ff43658854148b401f24075c0aa390e3b52187ab67cab0043f2b15e754a68 AS stage1
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
+
+# golang:1.15.7
+FROM golang@sha256:c161abf0cde3969e05f6914a86cab804b2b0df515f4ff9570475b25547ba7959 AS stage1
 
 ENV GOCACHE=/root/.cache/go/gocache
 ENV GOMODCACHE=/root/.cache/go/gomodcache

--- a/docker/l2/Dockerfile
+++ b/docker/l2/Dockerfile
@@ -1,7 +1,11 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
 
-# golang:1.15.2
-FROM golang@sha256:da7ff43658854148b401f24075c0aa390e3b52187ab67cab0043f2b15e754a68 AS stage1
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
+
+# golang:1.15.7
+FROM golang@sha256:c161abf0cde3969e05f6914a86cab804b2b0df515f4ff9570475b25547ba7959 AS stage1
 
 ENV GOCACHE=/root/.cache/go/gocache
 ENV GOMODCACHE=/root/.cache/go/gomodcache

--- a/docker/pwd/Dockerfile
+++ b/docker/pwd/Dockerfile
@@ -1,7 +1,11 @@
-# syntax = docker/dockerfile:experimental@sha256:de85b2f3a3e8a2f7fe48e8e84a65f6fdd5cd5183afa6412fff9caa6871649c44
+# syntax = docker/dockerfile@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+# SHA256 above is an absolute reference to docker/dockerfile:1.2.1
 
-# golang:1.15.2
-FROM golang@sha256:da7ff43658854148b401f24075c0aa390e3b52187ab67cab0043f2b15e754a68 AS stage1
+# The comment regarding the syntax reference is not at the top of the file
+# because the syntax line must be the first in the file.
+
+# golang:1.15.7
+FROM golang@sha256:c161abf0cde3969e05f6914a86cab804b2b0df515f4ff9570475b25547ba7959 AS stage1
 
 ENV GOCACHE=/root/.cache/go/gocache
 ENV GOMODCACHE=/root/.cache/go/gomodcache

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -9,6 +9,9 @@ import "github.com/SchemaStore/schemastore/src/schemas/json"
 	{file: "wip.yml", schema:     wip},
 ]
 
+_#latestUbuntu: "ubuntu-18.04"
+_#latestGo:     "1.15.7"
+
 #testWorkflow: json.#Workflow & {
 	env: {
 		DOCKER_HUB_USER:                    "playwithgopher"
@@ -23,7 +26,7 @@ import "github.com/SchemaStore/schemastore/src/schemas/json"
 		strategy: {
 			"fail-fast": false
 			matrix: {
-				go_version: ["1.15.4"]
+				go_version: [_#latestGo]
 			}
 		}
 		"runs-on": "${{ matrix.os }}"
@@ -107,7 +110,7 @@ test: {
 		pull_request: branches: ["**"]
 		schedule: [{cron: "0 9 * * *"}]
 	}
-	jobs: test: strategy: matrix: os: ["ubuntu-18.04"]
+	jobs: test: strategy: matrix: os: [_#latestUbuntu]
 }
 
 testmac: {
@@ -128,7 +131,7 @@ wip: json.#Workflow & {
 		env: {
 			GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 		}
-		"runs-on": "ubuntu-18.04"
+		"runs-on": _#latestUbuntu
 		steps: [{
 			uses: "myitcv/wip@v1.0.0"
 			with: {


### PR DESCRIPTION
We currently use an experimental version of dockerfile. Use an official
version of the buildkit frontend.

Also make a minor tweak to CI to use an explicit version of Ubuntu
rather than the moving feast that is "latest".

Also use the latest Go in CI.