### PR TITLE
guides: move to latest Go versions

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -43,7 +43,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### Create a module that others can use
@@ -753,14 +753,14 @@ The tests should pass:
 
 <pre data-command-src="Z28gdGVzdApnbyB0ZXN0IC12Cg=="><code class="language-.term1">$ go test
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.003s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.004s
 </code></pre>
 
 You will now break the `greetings.Hello` function to view a failing test. The `TestHelloName` test function
@@ -919,7 +919,7 @@ And re-run `go test` to verify our change:
 
 <pre data-command-src="Z28gdGVzdAo="><code class="language-.term1">$ go test
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.003s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
 </code></pre>
 
 This section introduced Go's built-in support for unit testing. In the next section, you'll see how to compile and

--- a/_posts/2019-10-15-get-started-with-go_go115_en.markdown
+++ b/_posts/2019-10-15-get-started-with-go_go115_en.markdown
@@ -29,7 +29,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### Write some code

--- a/_posts/2020-08-13-installing-go_go115_en.markdown
+++ b/_posts/2020-08-13-installing-go_go115_en.markdown
@@ -36,12 +36,12 @@ Start in your home directory:
 
 Download the latest version of Go:
 
-<pre data-command-src="d2dldCAtcSBodHRwczovL2dvbGFuZy5vcmcvZGwvZ28xLjE1LjUubGludXgtYW1kNjQudGFyLmd6Cg=="><code class="language-.term1">$ wget -q https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
+<pre data-command-src="d2dldCAtcSBodHRwczovL2dvbGFuZy5vcmcvZGwvZ28xLjE1LjcubGludXgtYW1kNjQudGFyLmd6Cg=="><code class="language-.term1">$ wget -q https://golang.org/dl/go1.15.7.linux-amd64.tar.gz
 </code></pre>
 
 Extract and install:
 
-<pre data-command-src="c3VkbyB0YXIgLUMgL3Vzci9sb2NhbCAteHpmIGdvMS4xNS41LmxpbnV4LWFtZDY0LnRhci5nego="><code class="language-.term1">$ sudo tar -C /usr/local -xzf go1.15.5.linux-amd64.tar.gz
+<pre data-command-src="c3VkbyB0YXIgLUMgL3Vzci9sb2NhbCAteHpmIGdvMS4xNS43LmxpbnV4LWFtZDY0LnRhci5nego="><code class="language-.term1">$ sudo tar -C /usr/local -xzf go1.15.7.linux-amd64.tar.gz
 </code></pre>
 
 Add the install target to your profile `PATH`:
@@ -57,7 +57,7 @@ Source your profile to test the new settings:
 Verify the Go installation:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### The Go environment

--- a/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
+++ b/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
@@ -33,7 +33,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### Why `stringer`?

--- a/_posts/2020-11-08-retract-module-versions_go116_en.markdown
+++ b/_posts/2020-11-08-retract-module-versions_go116_en.markdown
@@ -50,7 +50,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+go version go1.16beta1 linux/amd64
 </code></pre>
 
 ### The `proverb` module
@@ -134,6 +134,7 @@ Add a dependency on the `{% raw %}{{{.PROVERB}}}{% endraw %}` module:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QHYwLjEuMAo="><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.1.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0
+go get: added &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0
 </code></pre>
 
 Run to make sure everything works:
@@ -188,6 +189,7 @@ try this out:
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpnbyBnZXQge3t7LlBST1ZFUkJ9fX1AdjAuMi4wCmdvIHJ1biAuCg=="><code class="language-.term1">$ cd /home/gopher/gopher
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0
+go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0 =&gt; v0.2.0
 $ go run .
 Concurrency is parallelism.
 </code></pre>
@@ -270,6 +272,7 @@ Return to your `gopher` module to use this new version:
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpnbyBnZXQge3t7LlBST1ZFUkJ9fX1AdjAuMy4wCg=="><code class="language-.term1">$ cd /home/gopher/gopher
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.3.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0
+go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0 =&gt; v0.3.0
 </code></pre>
 
 This step also ensures that [proxy.golang.org](https://proxy.golang.org/) is now aware of `v0.3.0`.
@@ -320,8 +323,9 @@ Ah, there is the mischievous `v0.2.0`.
 So what would happen if you were to rely on the now retracted `v0.2.0`?
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QHYwLjIuMAo="><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0
-go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0 is retracted: Go proverb was totally wrong
+go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0: retracted by module author: Go proverb was totally wrong
 go: run &#39;go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest&#39; to switch to the latest unretracted version
+go get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v0.2.0
 </code></pre>
 
 A helpful message is printed, warning that you are now depending on a retracted version. Notice that this error message
@@ -346,6 +350,7 @@ gopher
 Let's follow the advice of the warning message, and return to the latest un-retracted version:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QGxhdGVzdAo="><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest
+go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0 =&gt; v0.3.0
 </code></pre>
 
 ### Another type of proverb
@@ -443,14 +448,17 @@ Ensure proxy.golang.org is aware of the new versions of `proverb` you just publi
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QHYxLjAuMApnbyBnZXQge3t7LlBST1ZFUkJ9fX1AdjEuMC4xCmdvIGdldCB7e3suUFJPVkVSQn19fUB2MC40LjAK"><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0
-go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.0 is retracted: Published v1 too early
+go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.0: retracted by module author: Published v1 too early
 go: run &#39;go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest&#39; to switch to the latest unretracted version
+go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v1.0.0
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1
-go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1 is retracted: Published v1 too early
+go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1: retracted by module author: Published v1 too early
 go: run &#39;go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest&#39; to switch to the latest unretracted version
+go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0 =&gt; v1.0.1
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.4.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.4.0
+go get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1 =&gt; v0.4.0
 </code></pre>
 
 _Note: you might not see the warning about either `v1.0.0` or `v1.0.1` being

--- a/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
+++ b/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
@@ -29,7 +29,7 @@ You should already have completed:
 This guide is running with:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+go version go1.16beta1 linux/amd64
 </code></pre>
 
 ### Background
@@ -104,7 +104,7 @@ v1.4.2
 You can also use `go version` to see the module dependencies used in building the program:
 
 <pre data-command-src="Z28gdmVyc2lvbiAtbSAkKHdoaWNoIG1rY2VydCkK"><code class="language-.term1">$ go version -m $(which mkcert)
-/home/gopher/go/bin/mkcert: devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000
+/home/gopher/go/bin/mkcert: go1.16beta1
 	path	filippo.io/mkcert
 	mod	filippo.io/mkcert	v1.4.2	h1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 	dep	golang.org/x/net	v0.0.0-20190620200207-3b0461eec859	h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=

--- a/_posts/2020-11-09-using-staticcheck_go115_en.markdown
+++ b/_posts/2020-11-09-using-staticcheck_go115_en.markdown
@@ -36,7 +36,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### Installing Staticcheck

--- a/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
+++ b/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
@@ -32,7 +32,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### The `public` and `private` modules

--- a/_posts/2020-11-19-major-version-repository-structure_go115_en.markdown
+++ b/_posts/2020-11-19-major-version-repository-structure_go115_en.markdown
@@ -23,7 +23,7 @@ In this guide you will:
 ### Context
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 </code></pre>
 
 ### Major branch strategy

--- a/guide.cue
+++ b/guide.cue
@@ -10,10 +10,10 @@ Networks: *["playwithgo_pwg"] | [...string]
 
 Delims: ["{{{", "}}}"]
 
-_#installGo:          "playwithgo/installgo1.15.5@sha256:8eedcce072b4296d3aad40b83ecc06252bfb91d64318b7d0f12081846fe6fd5d"
-_#go115LatestVersion: "go1.15.5"
-_#go115LatestImage:   "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
-_#go116LatestImage:   "playwithgo/go1.16-tip@sha256:dd9175b42b77df02298fb9f601895516c1963a51be8a023b1659843d47a1fe1b"
+_#installGo:          "playwithgo/installgo1.15.7@sha256:2994cd07143aeab4fd8e90a09f30716c9441c6c340c12a69a96babd4eca7b06e"
+_#go115LatestVersion: "go1.15.7"
+_#go115LatestImage:   "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+_#go116LatestImage:   "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
 
 _#golangToolsLatest: "v0.0.0-20201105220310-78b158585360"
 

--- a/guides/2018-10-19-go-fundamentals/go115_en_log.txt
+++ b/guides/2018-10-19-go-fundamentals/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ pwd
 /home/gopher
 $ mkdir /home/gopher/greetings
@@ -385,14 +385,14 @@ func TestHelloEmpty(t *testing.T) {
 EOD
 $ go test
 PASS
-ok  	{{{.GREETINGS}}}	0.002s
+ok  	{{{.GREETINGS}}}	0.003s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	{{{.GREETINGS}}}	0.002s
+ok  	{{{.GREETINGS}}}	0.004s
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 
@@ -534,7 +534,7 @@ func randomFormat() string {
 EOD
 $ go test
 PASS
-ok  	{{{.GREETINGS}}}	0.003s
+ok  	{{{.GREETINGS}}}	0.002s
 $ cd /home/gopher/hello
 $ go list -f '{{.Target}}'
 /home/gopher/go/bin/hello

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -142,11 +142,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -1524,7 +1524,7 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.002s
+				ok  \t{{{.GREETINGS}}}\t0.003s
 
 				"""
 			ComparisonOutput: """
@@ -1542,7 +1542,7 @@ Steps: {
 				=== RUN   TestHelloEmpty
 				--- PASS: TestHelloEmpty (0.00s)
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.002s
+				ok  \t{{{.GREETINGS}}}\t0.004s
 
 				"""
 			ComparisonOutput: """
@@ -1886,7 +1886,7 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.003s
+				ok  \t{{{.GREETINGS}}}\t0.002s
 
 				"""
 			ComparisonOutput: """
@@ -1990,5 +1990,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "8872560175aaabfb11445cd5a1c11ce65c901f76737e6bd7564aa1f0a7a98dc2"
+Hash: "d1730934b6fc7950acf42007c3654174690deaaad283da1145df0999958f8d76"
 Delims: ["{{{", "}}}"]

--- a/guides/2019-10-15-get-started-with-go/go115_en_log.txt
+++ b/guides/2019-10-15-get-started-with-go/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ pwd
 /home/gopher
 $ mkdir /home/gopher/hello

--- a/guides/2019-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2019-10-15-get-started-with-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -29,11 +29,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -223,5 +223,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "ac8ae1cb7871542e8f2de443eea2ffd4327c8a23b494dcacf9834d5e27b12154"
+Hash: "d327a1fdfa725e1490797bf54eb8411c86a82066443fd9f29e05e379b4f6597b"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-08-13-installing-go/go115_en_log.txt
+++ b/guides/2020-08-13-installing-go/go115_en_log.txt
@@ -1,11 +1,11 @@
 $ pwd
 /home/gopher
-$ wget -q https://golang.org/dl/go1.15.5.linux-amd64.tar.gz
-$ sudo tar -C /usr/local -xzf go1.15.5.linux-amd64.tar.gz
+$ wget -q https://golang.org/dl/go1.15.7.linux-amd64.tar.gz
+$ sudo tar -C /usr/local -xzf go1.15.7.linux-amd64.tar.gz
 $ echo export PATH="/usr/local/go/bin:$PATH" >>$HOME/.profile
 $ source $HOME/.profile
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ go env
 GO111MODULE=""
 GOARCH="amd64"

--- a/guides/2020-08-13-installing-go/out/gen_out.cue
+++ b/guides/2020-08-13-installing-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/installgo1.15.5@sha256:8eedcce072b4296d3aad40b83ecc06252bfb91d64318b7d0f12081846fe6fd5d"
+			Image: "playwithgo/installgo1.15.7@sha256:2994cd07143aeab4fd8e90a09f30716c9441c6c340c12a69a96babd4eca7b06e"
 		}
 	}
 }]
@@ -47,7 +47,7 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
-			CmdStr:           "wget -q https://golang.org/dl/go1.15.5.linux-amd64.tar.gz"
+			CmdStr:           "wget -q https://golang.org/dl/go1.15.7.linux-amd64.tar.gz"
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
@@ -62,7 +62,7 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
-			CmdStr:           "sudo tar -C /usr/local -xzf go1.15.5.linux-amd64.tar.gz"
+			CmdStr:           "sudo tar -C /usr/local -xzf go1.15.7.linux-amd64.tar.gz"
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
@@ -110,11 +110,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -454,5 +454,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "671c3905de661944d51a8e4e5161aac1ec6e6233cc9b59d92addef0f8a4a0ac9"
+Hash: "8c1de948c3657284626c6081b305129699f390f220d9820382c34bc6b8dc83e8"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -336,5 +336,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "c2418e3476016b911885730d9ffdb4210dcb5dbfce2bfca37e133d4f04f93ec1"
+Hash: "e366ec032e360dbde8062908d3756581a69420ffbafd2c7a8d12192c4e7e933f"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -340,5 +340,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "a9ceefc13ad981af73d8988ab6988cd7d3c5f237bde6e1ee99b7c228142c3279"
+Hash: "70a021fe16ca7d7462deac8afd96ac27d5eed7162aa83a8f92472f26a2ba132f"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
+++ b/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ mkdir painkiller
 $ cd painkiller
 $ go mod init painkiller

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -138,11 +138,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -781,5 +781,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "60d27687ea35eae6a1a0481d1ded97f6b0cb1c641cc6bc26d07497857dfa9372"
+Hash: "ca37d5a14ed3aa4f6ed2dcfb2257f71318e7b020f0595c13c56058bdbb60711a"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/go116_en_log.txt
+++ b/guides/2020-11-08-retract-module-versions/go116_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+go version go1.16beta1 linux/amd64
 $ mkdir /home/gopher/proverb
 $ cd /home/gopher/proverb
 $ git init -q
@@ -45,6 +45,7 @@ func main() {
 EOD
 $ go get {{{.PROVERB}}}@v0.1.0
 go: downloading {{{.PROVERB}}} v0.1.0
+go get: added {{{.PROVERB}}} v0.1.0
 $ go run .
 Don't communicate by sharing memory, share memory by communicating.
 $ cd /home/gopher/proverb
@@ -70,6 +71,7 @@ remote: Processed 1 references in total
 $ cd /home/gopher/gopher
 $ go get {{{.PROVERB}}}@v0.2.0
 go: downloading {{{.PROVERB}}} v0.2.0
+go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 $ go run .
 Concurrency is parallelism.
 $ cd /home/gopher/proverb
@@ -111,6 +113,7 @@ $ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ cd /home/gopher/gopher
 $ go get {{{.PROVERB}}}@v0.3.0
 go: downloading {{{.PROVERB}}} v0.3.0
+go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 $ go run .
 Concurrency is not parallelism.
 $ sleep 1m
@@ -119,14 +122,16 @@ $ go list -m -versions {{{.PROVERB}}}
 $ go list -m -versions -retracted {{{.PROVERB}}}
 {{{.PROVERB}}} v0.1.0 v0.2.0 v0.3.0
 $ go get {{{.PROVERB}}}@v0.2.0
-go: warning: {{{.PROVERB}}}@v0.2.0 is retracted: Go proverb was totally wrong
+go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 $ go run .
 Concurrency is parallelism.
 $ go list -m -u all
 gopher
 {{{.PROVERB}}} v0.2.0 (retracted) [v0.3.0]
 $ go get {{{.PROVERB}}}@latest
+go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 $ cd /home/gopher/proverb
 $ cat <<EOD > /home/gopher/proverb/proverb.go
 package proverb
@@ -184,14 +189,17 @@ $ cd /home/gopher/gopher
 $ (cd $(mktemp -d); export GOPATH=$(mktemp -d); go mod init mod.com; go get -x {{{.PROVERB}}}@v0.4.0; go get -x {{{.PROVERB}}}@v1.0.0; go get -x {{{.PROVERB}}}@v1.0.1; sleep 1m) >/dev/null 2>&1
 $ go get {{{.PROVERB}}}@v1.0.0
 go: downloading {{{.PROVERB}}} v1.0.0
-go: warning: {{{.PROVERB}}}@v1.0.0 is retracted: Published v1 too early
+go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 $ go get {{{.PROVERB}}}@v1.0.1
 go: downloading {{{.PROVERB}}} v1.0.1
-go: warning: {{{.PROVERB}}}@v1.0.1 is retracted: Published v1 too early
+go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 $ go get {{{.PROVERB}}}@v0.4.0
 go: downloading {{{.PROVERB}}} v0.4.0
+go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 $ sleep 1m
 $ go list -m -versions -retracted {{{.PROVERB}}}
 {{{.PROVERB}}} v0.1.0 v0.2.0 v0.3.0 v0.4.0 v1.0.0 v1.0.1

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16-tip@sha256:dd9175b42b77df02298fb9f601895516c1963a51be8a023b1659843d47a1fe1b"
+			Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
 		}
 	}
 }]
@@ -138,11 +138,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+				go version go1.16beta1 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+				go version go1.16beta1 linux/amd64
 
 				"""
 		}]
@@ -362,10 +362,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.1.0
+				go get: added {{{.PROVERB}}} v0.1.0
 
 				"""
 			ComparisonOutput: """
 
+				go get: added {{{.PROVERB}}} v0.1.0
 				go: downloading {{{.PROVERB}}} v0.1.0
 				"""
 		}]
@@ -533,10 +535,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.2.0
+				go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 
 				"""
 			ComparisonOutput: """
 
+				go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 				go: downloading {{{.PROVERB}}} v0.2.0
 				"""
 		}, {
@@ -750,10 +754,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.3.0
+				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 
 				"""
 			ComparisonOutput: """
 
+				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 				go: downloading {{{.PROVERB}}} v0.3.0
 				"""
 		}]
@@ -848,14 +854,16 @@ Steps: {
 			CmdStr:   "go get {{{.PROVERB}}}@v0.2.0"
 			ExitCode: 0
 			Output: """
-				go: warning: {{{.PROVERB}}}@v0.2.0 is retracted: Go proverb was totally wrong
+				go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+				go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 
 				"""
 			ComparisonOutput: """
 
+				go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-				go: warning: {{{.PROVERB}}}@v0.2.0 is retracted: Go proverb was totally wrong
+				go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 				"""
 		}]
 	}
@@ -911,11 +919,17 @@ Steps: {
 		Order:           31
 		Terminal:        "term1"
 		Stmts: [{
-			Negated:          false
-			CmdStr:           "go get {{{.PROVERB}}}@latest"
-			ExitCode:         0
-			Output:           ""
-			ComparisonOutput: ""
+			Negated:  false
+			CmdStr:   "go get {{{.PROVERB}}}@latest"
+			ExitCode: 0
+			Output: """
+				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+
+				"""
+			ComparisonOutput: """
+
+				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+				"""
 		}]
 	}
 	proverb_return_life: {
@@ -1222,15 +1236,17 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v1.0.0
-				go: warning: {{{.PROVERB}}}@v1.0.0 is retracted: Published v1 too early
+				go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+				go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 
 				"""
 			ComparisonOutput: """
 
+				go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 				go: downloading {{{.PROVERB}}} v1.0.0
 				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-				go: warning: {{{.PROVERB}}}@v1.0.0 is retracted: Published v1 too early
+				go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 				"""
 		}, {
 			Negated:  false
@@ -1238,15 +1254,17 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v1.0.1
-				go: warning: {{{.PROVERB}}}@v1.0.1 is retracted: Published v1 too early
+				go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+				go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 
 				"""
 			ComparisonOutput: """
 
+				go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 				go: downloading {{{.PROVERB}}} v1.0.1
 				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-				go: warning: {{{.PROVERB}}}@v1.0.1 is retracted: Published v1 too early
+				go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 				"""
 		}, {
 			Negated:  false
@@ -1254,10 +1272,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.4.0
+				go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 
 				"""
 			ComparisonOutput: """
 
+				go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 				go: downloading {{{.PROVERB}}} v0.4.0
 				"""
 		}]
@@ -1383,5 +1403,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "e1c8d35ab8581afe945460fd0bdf275938a51880887776f395c054730c655dd8"
+Hash: "ac6a2d842da0d217c04846ec22b283ea7570e61288c76e553569275d41fe94ba"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
+++ b/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+go version go1.16beta1 linux/amd64
 $ go get filippo.io/mkcert@v1.4.2
 go: downloading filippo.io/mkcert v1.4.2
 go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
@@ -16,7 +16,7 @@ $ which mkcert
 $ mkcert -version
 v1.4.2
 $ go version -m $(which mkcert)
-/home/gopher/go/bin/mkcert: devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000
+/home/gopher/go/bin/mkcert: go1.16beta1
 	path	filippo.io/mkcert
 	mod	filippo.io/mkcert	v1.4.2	h1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 	dep	golang.org/x/net	v0.0.0-20190620200207-3b0461eec859	h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16-tip@sha256:dd9175b42b77df02298fb9f601895516c1963a51be8a023b1659843d47a1fe1b"
+			Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
 		}
 	}
 }]
@@ -29,11 +29,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+				go version go1.16beta1 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000 linux/amd64
+				go version go1.16beta1 linux/amd64
 
 				"""
 		}]
@@ -157,7 +157,7 @@ Steps: {
 			CmdStr:   "go version -m $(which mkcert)"
 			ExitCode: 0
 			Output: """
-				/home/gopher/go/bin/mkcert: devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000
+				/home/gopher/go/bin/mkcert: go1.16beta1
 				\tpath\tfilippo.io/mkcert
 				\tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 				\tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
@@ -166,7 +166,7 @@ Steps: {
 
 				"""
 			ComparisonOutput: """
-				/home/gopher/go/bin/mkcert: devel +7307e86afd Sun Nov 8 12:19:55 2020 +0000
+				/home/gopher/go/bin/mkcert: go1.16beta1
 				\tpath\tfilippo.io/mkcert
 				\tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 				\tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
@@ -177,5 +177,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "9d9edb7b3e802c97463d642f07788a586986e2e69c7c6ed50b47244ec09ec34f"
+Hash: "51faf1c8c0fbff500473a130df5ed890d83cd63a4eb3035b1065a0a435a3d3e7"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/go115_en_log.txt
+++ b/guides/2020-11-09-using-staticcheck/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ (cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)
 go: downloading honnef.co/go/tools v0.0.1-2020.1.6
 go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -29,11 +29,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -916,5 +916,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "aa681564b6cf425a81eef72dc96513137db80f5736abac51a9945a8ce79854e7"
+Hash: "4a0f42f0e3295bf44cb20f74406fefd149348617e81f33a9cecd6430d35bedc0"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
+++ b/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ mkdir /home/gopher/public
 $ cd /home/gopher/public
 $ go mod init {{{.PUBLIC}}}

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -142,11 +142,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -862,5 +862,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "b6ff8523e51c84d759a27f366a8cd9aac143fbf2264c87502c3b70fb3d639c2d"
+Hash: "c0c339ea51c28892704689700f8a084bb179f2772fe350086ca1c744595f8077"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
+++ b/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.5 linux/amd64
+go version go1.15.7 linux/amd64
 $ mkdir /home/gopher/branch
 $ cd /home/gopher/branch
 $ go mod init {{{.BRANCH}}}

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 		}
 	}
 }]
@@ -142,11 +142,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.5 linux/amd64
+				go version go1.15.7 linux/amd64
 
 				"""
 		}]
@@ -788,5 +788,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "9dcc78f1f5203b0a4e4fb42d497b127e80365958a2becdc6cd80424d3a96df60"
+Hash: "e2e883b7034065c51cf23c3da42bf50e001398d7683beb68ed926b32879d1b4d"
 Delims: ["{{{", "}}}"]

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -22,7 +22,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -40,7 +40,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -58,7 +58,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/installgo1.15.5@sha256:8eedcce072b4296d3aad40b83ecc06252bfb91d64318b7d0f12081846fe6fd5d"
+				Image: "playwithgo/installgo1.15.7@sha256:2994cd07143aeab4fd8e90a09f30716c9441c6c340c12a69a96babd4eca7b06e"
 			}
 		}
 	}]
@@ -87,7 +87,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -116,7 +116,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -145,7 +145,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -174,7 +174,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16-tip@sha256:dd9175b42b77df02298fb9f601895516c1963a51be8a023b1659843d47a1fe1b"
+				Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
 			}
 		}
 	}]
@@ -192,7 +192,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16-tip@sha256:dd9175b42b77df02298fb9f601895516c1963a51be8a023b1659843d47a1fe1b"
+				Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
 			}
 		}
 	}]
@@ -210,7 +210,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -243,7 +243,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]
@@ -276,7 +276,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.5@sha256:0dfb27b5c217fd1ada5143427363ffcf5842b460c52e31f377301b0c82bf1695"
+				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
 			}
 		}
 	}]


### PR DESCRIPTION
go1.16 = go1.16beta1
go1.15 = go1.15.7