### PR TITLE
guides: move to latest Go versions

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -30,7 +30,7 @@ This guide's sequence includes six brief topics that each illustrate a different
 This guide requires you to push code to remote source code repositories. A unique user, `{% raw %}{{{.GITEA_USERNAME}}}{% endraw %}`, has
 been automatically created for you, as have the repositories [`{% raw %}{{{.GREETINGS}}}{% endraw %}`](https://{% raw %}{{{.GREETINGS}}}{% endraw %}.git) and
 [`{% raw %}{{{.HELLO}}}{% endraw %}`](https://{% raw %}{{{.HELLO}}}{% endraw %}.git). For more details on how `play-with-go.dev` guides work, please see the
-[_Introduction to `play-with-go.dev` guides_](ntro-to-play-with-go-dev/) guide.
+[_Introduction to `play-with-go.dev` guides_](/intro-to-play-with-go-dev_go115_en) guide.
 
 ### Prerequisites
 
@@ -43,7 +43,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### Create a module that others can use
@@ -753,14 +753,14 @@ The tests should pass:
 
 <pre data-command-src="Z28gdGVzdApnbyB0ZXN0IC12Cg=="><code class="language-.term1">$ go test
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.003s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.004s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
 </code></pre>
 
 You will now break the `greetings.Hello` function to view a failing test. The `TestHelloName` test function

--- a/_posts/2019-10-15-get-started-with-go_go115_en.markdown
+++ b/_posts/2019-10-15-get-started-with-go_go115_en.markdown
@@ -29,7 +29,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### Write some code

--- a/_posts/2020-08-13-installing-go_go115_en.markdown
+++ b/_posts/2020-08-13-installing-go_go115_en.markdown
@@ -36,12 +36,12 @@ Start in your home directory:
 
 Download the latest version of Go:
 
-<pre data-command-src="d2dldCAtcSBodHRwczovL2dvbGFuZy5vcmcvZGwvZ28xLjE1LjcubGludXgtYW1kNjQudGFyLmd6Cg=="><code class="language-.term1">$ wget -q https://golang.org/dl/go1.15.7.linux-amd64.tar.gz
+<pre data-command-src="d2dldCAtcSBodHRwczovL2dvbGFuZy5vcmcvZGwvZ28xLjE1LjgubGludXgtYW1kNjQudGFyLmd6Cg=="><code class="language-.term1">$ wget -q https://golang.org/dl/go1.15.8.linux-amd64.tar.gz
 </code></pre>
 
 Extract and install:
 
-<pre data-command-src="c3VkbyB0YXIgLUMgL3Vzci9sb2NhbCAteHpmIGdvMS4xNS43LmxpbnV4LWFtZDY0LnRhci5nego="><code class="language-.term1">$ sudo tar -C /usr/local -xzf go1.15.7.linux-amd64.tar.gz
+<pre data-command-src="c3VkbyB0YXIgLUMgL3Vzci9sb2NhbCAteHpmIGdvMS4xNS44LmxpbnV4LWFtZDY0LnRhci5nego="><code class="language-.term1">$ sudo tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
 </code></pre>
 
 Add the install target to your profile `PATH`:
@@ -57,7 +57,7 @@ Source your profile to test the new settings:
 Verify the Go installation:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### The Go environment

--- a/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
+++ b/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
@@ -33,7 +33,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### Why `stringer`?
@@ -189,8 +189,8 @@ With the package dependency declared, you can now add a dependency on the module
 <pre data-command-src="Z28gZ2V0IGdvbGFuZy5vcmcveC90b29scy9jbWQvc3RyaW5nZXJAdjAuMC4wLTIwMjAxMTA1MjIwMzEwLTc4YjE1ODU4NTM2MAo="><code class="language-.term1">$ go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360
 go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 go: downloading golang.org/x/mod v0.3.0
+go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 </code></pre>
 
 You can see your new dependency in the project's `go.mod` file:

--- a/_posts/2020-11-08-retract-module-versions_go116_en.markdown
+++ b/_posts/2020-11-08-retract-module-versions_go116_en.markdown
@@ -50,7 +50,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.16beta1 linux/amd64
+go version go1.16 linux/amd64
 </code></pre>
 
 ### The `proverb` module
@@ -324,8 +324,8 @@ So what would happen if you were to rely on the now retracted `v0.2.0`?
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QHYwLjIuMAo="><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0
 go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0: retracted by module author: Go proverb was totally wrong
-go: run &#39;go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest&#39; to switch to the latest unretracted version
-go get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v0.2.0
+go: to switch to the latest unretracted version, run:
+	go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latestgo get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v0.2.0
 </code></pre>
 
 A helpful message is printed, warning that you are now depending on a retracted version. Notice that this error message
@@ -449,13 +449,13 @@ Ensure proxy.golang.org is aware of the new versions of `proverb` you just publi
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QHYxLjAuMApnbyBnZXQge3t7LlBST1ZFUkJ9fX1AdjEuMC4xCmdvIGdldCB7e3suUFJPVkVSQn19fUB2MC40LjAK"><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0
 go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.0: retracted by module author: Published v1 too early
-go: run &#39;go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest&#39; to switch to the latest unretracted version
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v1.0.0
+go: to switch to the latest unretracted version, run:
+	go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latestgo get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v1.0.0
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1
 go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1: retracted by module author: Published v1 too early
-go: run &#39;go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest&#39; to switch to the latest unretracted version
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0 =&gt; v1.0.1
+go: to switch to the latest unretracted version, run:
+	go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latestgo get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0 =&gt; v1.0.1
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.4.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.4.0
 go get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1 =&gt; v0.4.0

--- a/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
+++ b/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
@@ -29,7 +29,7 @@ You should already have completed:
 This guide is running with:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.16beta1 linux/amd64
+go version go1.16 linux/amd64
 </code></pre>
 
 ### Background
@@ -104,7 +104,7 @@ v1.4.2
 You can also use `go version` to see the module dependencies used in building the program:
 
 <pre data-command-src="Z28gdmVyc2lvbiAtbSAkKHdoaWNoIG1rY2VydCkK"><code class="language-.term1">$ go version -m $(which mkcert)
-/home/gopher/go/bin/mkcert: go1.16beta1
+/home/gopher/go/bin/mkcert: go1.16
 	path	filippo.io/mkcert
 	mod	filippo.io/mkcert	v1.4.2	h1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 	dep	golang.org/x/net	v0.0.0-20190620200207-3b0461eec859	h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=

--- a/_posts/2020-11-09-using-staticcheck_go115_en.markdown
+++ b/_posts/2020-11-09-using-staticcheck_go115_en.markdown
@@ -36,7 +36,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### Installing Staticcheck

--- a/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
+++ b/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
@@ -32,7 +32,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### The `public` and `private` modules

--- a/_posts/2020-11-19-major-version-repository-structure_go115_en.markdown
+++ b/_posts/2020-11-19-major-version-repository-structure_go115_en.markdown
@@ -23,7 +23,7 @@ In this guide you will:
 ### Context
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 </code></pre>
 
 ### Major branch strategy

--- a/guide.cue
+++ b/guide.cue
@@ -10,10 +10,10 @@ Networks: *["playwithgo_pwg"] | [...string]
 
 Delims: ["{{{", "}}}"]
 
-_#installGo:          "playwithgo/installgo1.15.7@sha256:2994cd07143aeab4fd8e90a09f30716c9441c6c340c12a69a96babd4eca7b06e"
-_#go115LatestVersion: "go1.15.7"
-_#go115LatestImage:   "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
-_#go116LatestImage:   "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
+_#installGo:          "playwithgo/installgo1.15.8@sha256:0e480b658f50b85b8eb40c426022d572709a93f6e0a7fe65475bea50ad172c5f"
+_#go115LatestVersion: "go1.15.8"
+_#go115LatestImage:   "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
+_#go116LatestImage:   "playwithgo/go1.16@sha256:3ae1950433998a2be8c8ce3b1cb6479e6541f1e32443447a24085cfe09e2c391"
 
 _#golangToolsLatest: "v0.0.0-20201105220310-78b158585360"
 

--- a/guides/2018-10-19-go-fundamentals/en.markdown
+++ b/guides/2018-10-19-go-fundamentals/en.markdown
@@ -28,7 +28,7 @@ This guide's sequence includes six brief topics that each illustrate a different
 This guide requires you to push code to remote source code repositories. A unique user, `{{{.username}}}`, has
 been automatically created for you, as have the repositories [`{{{ .greetings_mod }}}`]({{{ .greetings_vcs }}}) and
 [`{{{ .hello_mod }}}`]({{{ .hello_vcs }}}). For more details on how `play-with-go.dev` guides work, please see the
-[_Introduction to `play-with-go.dev` guides_](ntro-to-play-with-go-dev/) guide.
+[_Introduction to `play-with-go.dev` guides_](/intro-to-play-with-go-dev_go115_en) guide.
 
 ### Prerequisites
 

--- a/guides/2018-10-19-go-fundamentals/go115_en_log.txt
+++ b/guides/2018-10-19-go-fundamentals/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ pwd
 /home/gopher
 $ mkdir /home/gopher/greetings
@@ -385,14 +385,14 @@ func TestHelloEmpty(t *testing.T) {
 EOD
 $ go test
 PASS
-ok  	{{{.GREETINGS}}}	0.003s
+ok  	{{{.GREETINGS}}}	0.002s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	{{{.GREETINGS}}}	0.004s
+ok  	{{{.GREETINGS}}}	0.002s
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -142,11 +142,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -1524,7 +1524,7 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.003s
+				ok  \t{{{.GREETINGS}}}\t0.002s
 
 				"""
 			ComparisonOutput: """
@@ -1542,7 +1542,7 @@ Steps: {
 				=== RUN   TestHelloEmpty
 				--- PASS: TestHelloEmpty (0.00s)
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.004s
+				ok  \t{{{.GREETINGS}}}\t0.002s
 
 				"""
 			ComparisonOutput: """
@@ -1990,5 +1990,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "d1730934b6fc7950acf42007c3654174690deaaad283da1145df0999958f8d76"
+Hash: "67e8fa42ea3d29d57918739b3666c60cf7a1035284bb687a04fc499525dbb75c"
 Delims: ["{{{", "}}}"]

--- a/guides/2019-10-15-get-started-with-go/go115_en_log.txt
+++ b/guides/2019-10-15-get-started-with-go/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ pwd
 /home/gopher
 $ mkdir /home/gopher/hello

--- a/guides/2019-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2019-10-15-get-started-with-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -29,11 +29,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -223,5 +223,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "d327a1fdfa725e1490797bf54eb8411c86a82066443fd9f29e05e379b4f6597b"
+Hash: "5e0e904bed1155519dbd746e845ffea1e654850fc1c0f6a44f42b3056f18f752"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-08-13-installing-go/go115_en_log.txt
+++ b/guides/2020-08-13-installing-go/go115_en_log.txt
@@ -1,11 +1,11 @@
 $ pwd
 /home/gopher
-$ wget -q https://golang.org/dl/go1.15.7.linux-amd64.tar.gz
-$ sudo tar -C /usr/local -xzf go1.15.7.linux-amd64.tar.gz
+$ wget -q https://golang.org/dl/go1.15.8.linux-amd64.tar.gz
+$ sudo tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz
 $ echo export PATH="/usr/local/go/bin:$PATH" >>$HOME/.profile
 $ source $HOME/.profile
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ go env
 GO111MODULE=""
 GOARCH="amd64"

--- a/guides/2020-08-13-installing-go/out/gen_out.cue
+++ b/guides/2020-08-13-installing-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/installgo1.15.7@sha256:2994cd07143aeab4fd8e90a09f30716c9441c6c340c12a69a96babd4eca7b06e"
+			Image: "playwithgo/installgo1.15.8@sha256:0e480b658f50b85b8eb40c426022d572709a93f6e0a7fe65475bea50ad172c5f"
 		}
 	}
 }]
@@ -47,7 +47,7 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
-			CmdStr:           "wget -q https://golang.org/dl/go1.15.7.linux-amd64.tar.gz"
+			CmdStr:           "wget -q https://golang.org/dl/go1.15.8.linux-amd64.tar.gz"
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
@@ -62,7 +62,7 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
-			CmdStr:           "sudo tar -C /usr/local -xzf go1.15.7.linux-amd64.tar.gz"
+			CmdStr:           "sudo tar -C /usr/local -xzf go1.15.8.linux-amd64.tar.gz"
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
@@ -110,11 +110,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -454,5 +454,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "8c1de948c3657284626c6081b305129699f390f220d9820382c34bc6b8dc83e8"
+Hash: "1b982601bb294dceed967a1fb792c75e7e4e7091d45fa2740301f29e52845bea"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -336,5 +336,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "e366ec032e360dbde8062908d3756581a69420ffbafd2c7a8d12192c4e7e933f"
+Hash: "904cc774ffe86285a7a18337e5f744af4491c371faa854941bed09399c3dfdb1"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -340,5 +340,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "70a021fe16ca7d7462deac8afd96ac27d5eed7162aa83a8f92472f26a2ba132f"
+Hash: "580b398681731b21943b32112f4ca0a78c06ae14cf089451ea690ae7a06a4627"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
+++ b/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ mkdir painkiller
 $ cd painkiller
 $ go mod init painkiller
@@ -83,8 +83,8 @@ EOD
 $ go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360
 go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 go: downloading golang.org/x/mod v0.3.0
+go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 $ cat go.mod
 module painkiller
 

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -138,11 +138,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -397,8 +397,8 @@ Steps: {
 			Output: """
 				go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 				go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-				go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 				go: downloading golang.org/x/mod v0.3.0
+				go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 
 				"""
 			ComparisonOutput: """
@@ -781,5 +781,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "ca37d5a14ed3aa4f6ed2dcfb2257f71318e7b020f0595c13c56058bdbb60711a"
+Hash: "f4d3f795f9300ba48a15ccbeb232f99867ecc16a6198f0a850bab5195d46d626"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/go116_en_log.txt
+++ b/guides/2020-11-08-retract-module-versions/go116_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.16beta1 linux/amd64
+go version go1.16 linux/amd64
 $ mkdir /home/gopher/proverb
 $ cd /home/gopher/proverb
 $ git init -q
@@ -123,8 +123,8 @@ $ go list -m -versions -retracted {{{.PROVERB}}}
 {{{.PROVERB}}} v0.1.0 v0.2.0 v0.3.0
 $ go get {{{.PROVERB}}}@v0.2.0
 go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
-go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+go: to switch to the latest unretracted version, run:
+	go get {{{.PROVERB}}}@latestgo get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 $ go run .
 Concurrency is parallelism.
 $ go list -m -u all
@@ -190,13 +190,13 @@ $ (cd $(mktemp -d); export GOPATH=$(mktemp -d); go mod init mod.com; go get -x {
 $ go get {{{.PROVERB}}}@v1.0.0
 go: downloading {{{.PROVERB}}} v1.0.0
 go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
-go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
+go: to switch to the latest unretracted version, run:
+	go get {{{.PROVERB}}}@latestgo get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 $ go get {{{.PROVERB}}}@v1.0.1
 go: downloading {{{.PROVERB}}} v1.0.1
 go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
-go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
+go: to switch to the latest unretracted version, run:
+	go get {{{.PROVERB}}}@latestgo get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 $ go get {{{.PROVERB}}}@v0.4.0
 go: downloading {{{.PROVERB}}} v0.4.0
 go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
+			Image: "playwithgo/go1.16@sha256:3ae1950433998a2be8c8ce3b1cb6479e6541f1e32443447a24085cfe09e2c391"
 		}
 	}
 }]
@@ -138,11 +138,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.16beta1 linux/amd64
+				go version go1.16 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.16beta1 linux/amd64
+				go version go1.16 linux/amd64
 
 				"""
 		}]
@@ -855,14 +855,14 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
-				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-				go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+				go: to switch to the latest unretracted version, run:
+				\tgo get {{{.PROVERB}}}@latestgo get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
-				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+				\tgo get {{{.PROVERB}}}@latestgo get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+				go: to switch to the latest unretracted version, run:
 				go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 				"""
 		}]
@@ -1237,15 +1237,15 @@ Steps: {
 			Output: """
 				go: downloading {{{.PROVERB}}} v1.0.0
 				go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
-				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-				go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
+				go: to switch to the latest unretracted version, run:
+				\tgo get {{{.PROVERB}}}@latestgo get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
+				\tgo get {{{.PROVERB}}}@latestgo get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 				go: downloading {{{.PROVERB}}} v1.0.0
-				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+				go: to switch to the latest unretracted version, run:
 				go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 				"""
 		}, {
@@ -1255,15 +1255,15 @@ Steps: {
 			Output: """
 				go: downloading {{{.PROVERB}}} v1.0.1
 				go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
-				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
-				go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
+				go: to switch to the latest unretracted version, run:
+				\tgo get {{{.PROVERB}}}@latestgo get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 
 				"""
 			ComparisonOutput: """
 
-				go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
+				\tgo get {{{.PROVERB}}}@latestgo get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 				go: downloading {{{.PROVERB}}} v1.0.1
-				go: run 'go get {{{.PROVERB}}}@latest' to switch to the latest unretracted version
+				go: to switch to the latest unretracted version, run:
 				go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 				"""
 		}, {
@@ -1403,5 +1403,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "ac6a2d842da0d217c04846ec22b283ea7570e61288c76e553569275d41fe94ba"
+Hash: "254791c02d718930e65df5631f0d9bfa49c9888c43a72c39e43dd02cb28d6fc0"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
+++ b/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.16beta1 linux/amd64
+go version go1.16 linux/amd64
 $ go get filippo.io/mkcert@v1.4.2
 go: downloading filippo.io/mkcert v1.4.2
 go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
@@ -16,7 +16,7 @@ $ which mkcert
 $ mkcert -version
 v1.4.2
 $ go version -m $(which mkcert)
-/home/gopher/go/bin/mkcert: go1.16beta1
+/home/gopher/go/bin/mkcert: go1.16
 	path	filippo.io/mkcert
 	mod	filippo.io/mkcert	v1.4.2	h1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 	dep	golang.org/x/net	v0.0.0-20190620200207-3b0461eec859	h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
+			Image: "playwithgo/go1.16@sha256:3ae1950433998a2be8c8ce3b1cb6479e6541f1e32443447a24085cfe09e2c391"
 		}
 	}
 }]
@@ -29,11 +29,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.16beta1 linux/amd64
+				go version go1.16 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.16beta1 linux/amd64
+				go version go1.16 linux/amd64
 
 				"""
 		}]
@@ -157,7 +157,7 @@ Steps: {
 			CmdStr:   "go version -m $(which mkcert)"
 			ExitCode: 0
 			Output: """
-				/home/gopher/go/bin/mkcert: go1.16beta1
+				/home/gopher/go/bin/mkcert: go1.16
 				\tpath\tfilippo.io/mkcert
 				\tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 				\tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
@@ -166,7 +166,7 @@ Steps: {
 
 				"""
 			ComparisonOutput: """
-				/home/gopher/go/bin/mkcert: go1.16beta1
+				/home/gopher/go/bin/mkcert: go1.16
 				\tpath\tfilippo.io/mkcert
 				\tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
 				\tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
@@ -177,5 +177,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "51faf1c8c0fbff500473a130df5ed890d83cd63a4eb3035b1065a0a435a3d3e7"
+Hash: "73c9091cdd99c62b11430bf2ac757aeba7a7ede663a24be8e64730b32a6bdc4b"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/go115_en_log.txt
+++ b/guides/2020-11-09-using-staticcheck/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ (cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)
 go: downloading honnef.co/go/tools v0.0.1-2020.1.6
 go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -29,11 +29,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -916,5 +916,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "4a0f42f0e3295bf44cb20f74406fefd149348617e81f33a9cecd6430d35bedc0"
+Hash: "3f5e010888de49ecffbbb7441e0b49feca502ef03b00d6b37c67955c88d5504a"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
+++ b/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ mkdir /home/gopher/public
 $ cd /home/gopher/public
 $ go mod init {{{.PUBLIC}}}

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -142,11 +142,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -862,5 +862,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "c0c339ea51c28892704689700f8a084bb179f2772fe350086ca1c744595f8077"
+Hash: "9d97954c3ee1cd4bde7c11746ea13c5a2042df6bfa03380d66499af1fd13989f"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
+++ b/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.7 linux/amd64
+go version go1.15.8 linux/amd64
 $ mkdir /home/gopher/branch
 $ cd /home/gopher/branch
 $ go mod init {{{.BRANCH}}}

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -118,7 +118,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+			Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 		}
 	}
 }]
@@ -142,11 +142,11 @@ Steps: {
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 			ComparisonOutput: """
-				go version go1.15.7 linux/amd64
+				go version go1.15.8 linux/amd64
 
 				"""
 		}]
@@ -788,5 +788,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "e2e883b7034065c51cf23c3da42bf50e001398d7683beb68ed926b32879d1b4d"
+Hash: "f85a6c555130c5ff73633c1f9abecf70038d37ad16da51308c3e7d51338fe483"
 Delims: ["{{{", "}}}"]

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -22,7 +22,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -40,7 +40,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -58,7 +58,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/installgo1.15.7@sha256:2994cd07143aeab4fd8e90a09f30716c9441c6c340c12a69a96babd4eca7b06e"
+				Image: "playwithgo/installgo1.15.8@sha256:0e480b658f50b85b8eb40c426022d572709a93f6e0a7fe65475bea50ad172c5f"
 			}
 		}
 	}]
@@ -87,7 +87,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -116,7 +116,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -145,7 +145,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -174,7 +174,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
+				Image: "playwithgo/go1.16@sha256:3ae1950433998a2be8c8ce3b1cb6479e6541f1e32443447a24085cfe09e2c391"
 			}
 		}
 	}]
@@ -192,7 +192,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16beta1@sha256:0495af40e1c11efbf4622aa79dc4f39bdade9026fce003334a3db6c34bd6ba7d"
+				Image: "playwithgo/go1.16@sha256:3ae1950433998a2be8c8ce3b1cb6479e6541f1e32443447a24085cfe09e2c391"
 			}
 		}
 	}]
@@ -210,7 +210,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -243,7 +243,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]
@@ -276,7 +276,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.7@sha256:29da7e55ee550cddc3f742d25756bf7ecfaa7c5a23c723f079f0c982a369fda4"
+				Image: "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 			}
 		}
 	}]


### PR DESCRIPTION
go1.16 = go1.16
go1.15 = go1.15.8

Until we have multi-scenario support we can't actually "bump" guides to
go1.16, because otherwise we will break people who are linking to the
go115 scenario.