### PR TITLE
deps: use latest preguide with fix for config loading

### DIFF
--- a/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
+++ b/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
@@ -189,8 +189,8 @@ With the package dependency declared, you can now add a dependency on the module
 <pre data-command-src="Z28gZ2V0IGdvbGFuZy5vcmcveC90b29scy9jbWQvc3RyaW5nZXJAdjAuMC4wLTIwMjAxMTA1MjIwMzEwLTc4YjE1ODU4NTM2MAo="><code class="language-.term1">$ go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360
 go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/mod v0.3.0
 go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+go: downloading golang.org/x/mod v0.3.0
 </code></pre>
 
 You can see your new dependency in the project's `go.mod` file:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
 	github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e0
 	github.com/play-with-go/gitea v0.0.0-20210221062040-e0aff1ca9bb5
-	github.com/play-with-go/preguide v0.0.2-0.20210221145801-1ad62d50f30a
+	github.com/play-with-go/preguide v0.0.2-0.20210223162556-900e02260be7
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 )

--- a/go.sum
+++ b/go.sum
@@ -408,8 +408,8 @@ github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e
 github.com/play-with-go/gitea v0.0.0-20210221062040-e0aff1ca9bb5 h1:gwdqqYsrbaxbWpF/lLkHKaEDax2+7kRXW1hX0gXp6bk=
 github.com/play-with-go/gitea v0.0.0-20210221062040-e0aff1ca9bb5/go.mod h1:StDppLLMMFhcg5PZirHHVH3eRtrfca2oop8by971MAM=
 github.com/play-with-go/preguide v0.0.2-0.20200929132054-e0f48a7f7b23/go.mod h1:jkhBBbIBioAzKiRo5Rr9r03tqglgUdPZAVIpBBw7aDU=
-github.com/play-with-go/preguide v0.0.2-0.20210221145801-1ad62d50f30a h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=
-github.com/play-with-go/preguide v0.0.2-0.20210221145801-1ad62d50f30a/go.mod h1:yPGc4XvlQfMjTP8AOTqiyLqwr1VcgNERf0riVQho8Cc=
+github.com/play-with-go/preguide v0.0.2-0.20210223162556-900e02260be7 h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=
+github.com/play-with-go/preguide v0.0.2-0.20210223162556-900e02260be7/go.mod h1:yPGc4XvlQfMjTP8AOTqiyLqwr1VcgNERf0riVQho8Cc=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -68,8 +68,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -1990,5 +1990,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "a7c269ecbd970517f6c20e0036bb3c170df0e3f579f73c5becfd738430b34fc5"
+Hash: "d17cad38d310e68514203e48664d446e6a5608d896e9760bad183e886e33ce33"
 Delims: ["{{{", "}}}"]

--- a/guides/2019-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2019-10-15-get-started-with-go/out/gen_out.cue
@@ -223,5 +223,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "e52e686360c5c922c676871c47875bb239d811b0a9ac902074c5cc27237ce813"
+Hash: "e551131559dc79067bb1a88495bcdfd6533f1870dbd3c9d7668143ab94da9b05"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-08-13-installing-go/out/gen_out.cue
+++ b/guides/2020-08-13-installing-go/out/gen_out.cue
@@ -454,5 +454,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "489456af75e69fdf3293690b55e80c73866dc3c1f69d12a791663e5c0a8fa432"
+Hash: "67e9ef00f178d0ed2c759276da5af95d79498fc1ddc519304ab946cb833b9de0"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -64,8 +64,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -336,5 +336,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "c8b1a428799afad8145062c872d2a74d14b1108a1a9f43bfc228cd65baf2a78e"
+Hash: "6dc0209632dbac57cb9a72c6df43c6ee3e29aed184363498419dde6615ec889f"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -64,8 +64,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -340,5 +340,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "b645cd25b75121c507c51d064a1e5467b42ae8c0fae7f3c468e1389e0d4e2141"
+Hash: "33cde245ed39ae9d739aef1b5f75475d1f01232373cf3a4d2d4df427b34b9acf"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
+++ b/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
@@ -83,8 +83,8 @@ EOD
 $ go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360
 go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/mod v0.3.0
 go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+go: downloading golang.org/x/mod v0.3.0
 $ cat go.mod
 module painkiller
 

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -64,8 +64,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -397,8 +397,8 @@ Steps: {
 			Output: """
 				go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
 				go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-				go: downloading golang.org/x/mod v0.3.0
 				go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+				go: downloading golang.org/x/mod v0.3.0
 
 				"""
 			ComparisonOutput: """
@@ -781,5 +781,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "a0a27b641f875dc08dcd88c2de337cb33f458bf6293b32dd895cf5fc59d5615e"
+Hash: "a3c8d3aa0781b18fd1ae004139be5c679f8e6a70a266b8b09bec2704668e824f"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -64,8 +64,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -1403,5 +1403,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "0d46f24816e5bb68efa0fb02c3415bff764945564b2c1d15c6896797cec353e2"
+Hash: "7db4e47215e9e1ba97b6cca7dd4b5787af753132abb6eed120337012810a852d"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -177,5 +177,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "965fb75badbbd379725685785feac67abb3303680692e7b8935ced74b5f982c0"
+Hash: "43b2d82b6689982a300d22dbbb308d1dc8fa2143c31b094dc6ac2a67dc372438"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -916,5 +916,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "ac942c966d104e8dce279098a7006ac87d7b732111f05bb628a19596ffddfe0a"
+Hash: "94a49f18c52a95042f1e5c6a64a0be92dd5278b4ca6de2f97a3075ec66d1bd96"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -68,8 +68,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -862,5 +862,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "63c464bf69fb7d5119e4b999a4c7dcd2c7b391f8fb147569ba1cf330add22bf9"
+Hash: "94dd37b2b02eeabf2f58cab3c8b77a367106e929b628b35b6b887da8e74cb180"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -68,8 +68,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20210221145801-1ad62d50f30a",
-		      "Sum": "h1:g0UXUL267v0eA6yEKPo206vFI2uOyjiBjkGyrVnfUVE=",
+		      "Version": "v0.0.2-0.20210223162556-900e02260be7",
+		      "Sum": "h1:80CJZTb64Fv/a7o9uquinfw70KekobrcSyX6+a4T3q0=",
 		      "Replace": null
 		    },
 		    {
@@ -788,5 +788,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "350526d9cfc74c4b11a7bb918d5ac374ecc96640414734ee402028aca333275b"
+Hash: "4b14bd799be0759965a82b6e4a4c056cd438c6fe8a7c4b9f67e0dfbca14db714"
 Delims: ["{{{", "}}}"]


### PR DESCRIPTION
Allows us to load preguide config irrespective of build constraints.
This is a hack for now until we have a better solution from preguide.