### PR TITLE
guides: remove mention about a preview

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ default-image: https://play-with-go.dev/images/playgo.png # If there is no featu
 guides-categories:
   - "Start here"
   - "Next steps"
-  - "What's coming in Go 1.16"
+  - "New features in Go 1.16"
 
 #footer
 built-by: The play-with-go.dev Authors

--- a/_posts/2020-11-08-retract-module-versions_go116_en.markdown
+++ b/_posts/2020-11-08-retract-module-versions_go116_en.markdown
@@ -1,5 +1,5 @@
 ---
-category: What's coming in Go 1.16
+category: New features in Go 1.16
 difficulty: Intermediate
 excerpt: Learn how to flag modules that shouldn't be used
 guide: 2020-11-08-retract-module-versions
@@ -10,8 +10,6 @@ title: Retract Module Versions
 
 _By [Jay Conrod](https://twitter.com/jayconrod), software engineer on the [Go](https://golang.org/) tools team, and
 principal author of module retraction in the `go` command._
-
-_Note: this is a preview of a `cmd/go` feature that is due to land in Go 1.16_
 
 Module authors need a way to indicate that published module versions should not be used. There are a number of reasons
 this may be needed:

--- a/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
+++ b/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
@@ -1,5 +1,5 @@
 ---
-category: What's coming in Go 1.16
+category: New features in Go 1.16
 difficulty: Beginner
 excerpt: Simple easy-to-remember way to install Go programs
 guide: 2020-11-09-installing-go-programs-directly
@@ -10,8 +10,6 @@ title: Installing Go programs directly
 
 _By [Daniel Martí](https://mvdan.cc), Go contributor, maintainer of [`encoding/json`](https://pkg.go.dev/encoding/json),
 and tool author._
-
-_Note: this is a preview of a `cmd/go` feature that is due to land in Go 1.16_
 
 Users need a simple, easy-to-remember way to install Go programs. Similarly, tool authors need a short one-liner they
 can include at the top of their `README.md` explaining how to install the tool.

--- a/guides/2020-11-08-retract-module-versions/en.markdown
+++ b/guides/2020-11-08-retract-module-versions/en.markdown
@@ -2,14 +2,12 @@
 layout: post
 title:  "Retract Module Versions"
 excerpt: "Learn how to flag modules that shouldn't be used"
-category: What's coming in Go 1.16
+category: New features in Go 1.16
 difficulty: Intermediate
 ---
 
 _By [Jay Conrod](https://twitter.com/jayconrod), software engineer on the [Go](https://golang.org/) tools team, and
 principal author of module retraction in the `go` command._
-
-_Note: this is a preview of a `cmd/go` feature that is due to land in Go 1.16_
 
 Module authors need a way to indicate that published module versions should not be used. There are a number of reasons
 this may be needed:

--- a/guides/2020-11-09-installing-go-programs-directly/en.markdown
+++ b/guides/2020-11-09-installing-go-programs-directly/en.markdown
@@ -2,14 +2,12 @@
 layout: post
 title:  "Installing Go programs directly"
 excerpt: "Simple easy-to-remember way to install Go programs"
-category: What's coming in Go 1.16
+category: New features in Go 1.16
 difficulty: Beginner
 ---
 
 _By [Daniel Martí](https://mvdan.cc), Go contributor, maintainer of [`encoding/json`](https://pkg.go.dev/encoding/json),
 and tool author._
-
-_Note: this is a preview of a `cmd/go` feature that is due to land in Go 1.16_
 
 Users need a simple, easy-to-remember way to install Go programs. Similarly, tool authors need a short one-liner they
 can include at the top of their `README.md` explaining how to install the tool.


### PR DESCRIPTION
Go 1.16 released and these features are officially now. So I think "preview" is no need.