### PR TITLE
ci: fix mac CI run

### DIFF
--- a/_scripts/macCISetup.sh
+++ b/_scripts/macCISetup.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 
 # With thanks/credit to https://github.com/docker/for-mac/issues/2359#issuecomment-607154849
 
+# Update brew to make sure we're using the latest formulae
+brew update
+
 ###############################
 # General
 brew install bash

--- a/cue.mod/tests/eval.txt
+++ b/cue.mod/tests/eval.txt
@@ -1,6 +1,9 @@
 # Verify that a simple eval works as expect
 
+# eval
 cue eval ./...
+
+# Compare vs golden files
 cmp stdout $WORK/stdout.golden
 
 -- stdout.golden --


### PR DESCRIPTION
Docker v3.2.0 was broken for mac. Explicitly use v3.2.1. Per:

    https://github.com/docker/for-mac/issues/5406