### PR TITLE
guides: fix link to prerequisites for fundamentals guides

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -37,8 +37,8 @@ been automatically created for you, as have the repositories [`{% raw %}{{{.GREE
 You should already have completed:
 
 * [The Go Tour](https://tour.golang.org/)
-* [An introduction to play-with-go.dev guides](/intro-to-play-with-go-dev/)
-* [Get started with Go](/get-started-with-go/)
+* [An introduction to play-with-go.dev guides](/intro-to-play-with-go-dev_go115_en/)
+* [Get started with Go](/get-started-with-go_go115_en/)
 
 This guide is running using:
 

--- a/guides/2018-10-19-go-fundamentals/en.markdown
+++ b/guides/2018-10-19-go-fundamentals/en.markdown
@@ -35,8 +35,8 @@ been automatically created for you, as have the repositories [`{{{ .greetings_mo
 You should already have completed:
 
 * [The Go Tour](https://tour.golang.org/)
-* [An introduction to play-with-go.dev guides](/intro-to-play-with-go-dev/)
-* [Get started with Go](/get-started-with-go/)
+* [An introduction to play-with-go.dev guides](/intro-to-play-with-go-dev_go115_en/)
+* [Get started with Go](/get-started-with-go_go115_en/)
 
 This guide is running using:
 


### PR DESCRIPTION
With thanks to @andersarpi and @peterhellberg for reporting this.