### PR TITLE
New guide to show case how to handle go version backwards compatibility

### DIFF
--- a/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
+++ b/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
@@ -1,0 +1,264 @@
+---
+category: Next steps
+difficulty: Intermediate
+excerpt: 'How to leverage go build flags to avoid breaking downstream projects '
+guide: 2021-05-02-build-flags-backwards-compatibility
+lang: en
+layout: post
+title: Using build flags for backwards compatibility
+---
+
+_By [Marcos Nils](https://twitter.com/marcosnils), [Docker Captain](https://www.docker.com/captains/marcos-lilljedahl), Hashicorp Ambassador, Go developer, and co-creator of `play-with-go.dev`._
+
+Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features on the standard library.
+As the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
+new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `embed` directive amongst others. 
+
+It's usually common to see developers wanting to adopt all these new features and refactor their code so they can take
+advantage of these interfaces to make their applications and libraries more modular, testable and sometimes
+even more performant. However, it's important to understand how these changes, if not done carefuly, can
+sometimes break downstream dependencies given that in the case of `go`, when you're importing a third party module,
+you're forced to build your project with the latest version of the complete dependency tree. 
+
+This guide explains how to deal with situations where you want to use new features of recent versions of `go`
+and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using 
+conditional compilation through `go build` tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
+package respectively. 
+
+
+### A simple go 1.15 program using ioutil.Discard
+
+Let's start by checking our current `go` 1.15 version:
+
+<pre data-command-src="Z28xMTUgdmVyc2lvbgo="><code class="language-.term1">$ go115 version
+go version go1.15.8 linux/amd64
+</code></pre>
+
+Now, we'll also check that we have `go` 1.16 installed as well:
+
+<pre data-command-src="Z28xMTYgdmVyc2lvbgo="><code class="language-.term1">$ go116 version
+go version go1.16.3 linux/amd64
+</code></pre>
+
+
+We'll start by setting `go` 1.15 as the default working version:
+
+<pre data-command-src="YWxpYXMgZ289Z28xMTUK"><code class="language-.term1">$ alias go=go115
+</code></pre>
+
+Start by a new `public` module:
+
+<pre data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL3B1YmxpYwpjZCAvaG9tZS9nb3BoZXIvcHVibGljCmdvIG1vZCBpbml0IHt7ey5QVUJMSUN9fX0KZ2l0IGluaXQgLXEKZ2l0IHJlbW90ZSBhZGQgb3JpZ2luIGh0dHBzOi8ve3t7LlBVQkxJQ319fS5naXQK"><code class="language-.term1">$ mkdir /home/gopher/public
+$ cd /home/gopher/public
+$ go mod init &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+go: creating new go.mod: module &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+$ git init -q
+$ git remote add origin https://&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;.git
+</code></pre>
+
+Now, we'll upload a simple `go` program that uses 1.15 `ioutil.Discard` in a public function:
+
+Create an initial version of the `DoSomething()` in `public.go`:
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL3B1YmxpYw==" data-upload-src="cHVibGljLmdv:cGFja2FnZSBwdWJsaWMKCmltcG9ydCAoCiAgICAiZm10IgogICAgImlvL2lvdXRpbCIKKQoKZnVuYyBEb1NvbWV0aGluZygpIHsKICAgIGZtdC5GcHJpbnRmKGlvdXRpbC5EaXNjYXJkLCAiVGhpcyBkb2Vzbid0IHByaW50IGFueXRoaW5nIikKfQ==" data-upload-term=".term1"><code class="language-go">package public
+
+import (
+    &#34;fmt&#34;
+    &#34;io/ioutil&#34;
+)
+
+func DoSomething() &#123;
+    fmt.Fprintf(ioutil.Discard, &#34;This doesn&#39;t print anything&#34;)
+&#125;</code></pre>
+
+Commit and push this initial version:
+
+<pre data-command-src="Z2l0IGFkZCBwdWJsaWMuZ28gZ28ubW9kCmdpdCBjb21taXQgLXEgLW0gJ0luaXRpYWwgY29tbWl0IG9mIHB1YmxpYyBtb2R1bGUnCmdpdCBwdXNoIC1xIG9yaWdpbiBtYWluCg=="><code class="language-.term1">$ git add public.go go.mod
+$ git commit -q -m &#39;Initial commit of public module&#39;
+$ git push -q origin main
+remote: . Processing 1 references        
+remote: Processed 1 references in total        
+</code></pre>
+
+### The `gopher` module
+
+Now create a `gopher` module to try out the `public` module. Unlike
+the `public` module, you will not publish the `gopher` module; it
+will be local only:
+
+<pre data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL2dvcGhlcgpjZCAvaG9tZS9nb3BoZXIvZ29waGVyCmdvIG1vZCBpbml0IGdvcGhlcgo="><code class="language-.term1">$ mkdir /home/gopher/gopher
+$ cd /home/gopher/gopher
+$ go mod init gopher
+go: creating new go.mod: module gopher
+</code></pre>
+
+Create an initial version of a `main` package that uses the previous public module, in `gopher.go`:
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL2dvcGhlcg==" data-upload-src="Z29waGVyLmdv:cGFja2FnZSBtYWluCgppbXBvcnQgKAoKInt7ey5QVUJMSUN9fX0iCikKCmZ1bmMgbWFpbigpIHsKICAgIHB1YmxpYy5Eb1NvbWV0aGluZygpCn0K" data-upload-term=".term1"><code class="language-go">package main
+
+import (
+
+&#34;&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;&#34;
+)
+
+func main() &#123;
+    public.DoSomething()
+&#125;
+</code></pre>
+
+
+Now, we'll run the `gopher` module `main` package:
+
+<pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .
+go: finding module for package &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210510022515-3b5a503cc6e3
+go: found &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; in &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210510022515-3b5a503cc6e3
+</code></pre>
+
+
+### Bumping the `public` dependency to `go` 1.16
+
+`Go` 1.16 has been released, and as good developers we want to refactor our
+code so it uses the new `io.Discard` variable instead of the deprecated `ioutil` one.
+
+
+First, we set our `go` version to 1.16:
+
+<pre data-command-src="YWxpYXMgZ289Z28xMTYK"><code class="language-.term1">$ alias go=go116
+</code></pre>
+
+Now, we change our original `public` module to use the new variable.
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL3B1YmxpYw==" data-upload-src="cHVibGljLmdv:cGFja2FnZSBwdWJsaWMKCmltcG9ydCAoCiAgICAiZm10IgogICAgImlvIgopCgpmdW5jIERvU29tZXRoaW5nKCkgewogICAgZm10LkZwcmludGYoaW8uRGlzY2FyZCwgIlRoaXMgZG9lc24ndCBwcmludCBhbnl0aGluZyIpCn0=" data-upload-term=".term1"><code class="language-go">package public
+
+import (
+    &#34;fmt&#34;
+    &#34;io&#34;
+)
+
+func DoSomething() &#123;
+    fmt.Fprintf(io.Discard, &#34;This doesn&#39;t print anything&#34;)
+&#125;</code></pre>
+
+
+Now we're good to release a new version of our `public` module
+using the `go` 1.16 new package:
+
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL3B1YmxpYwpnaXQgY2hlY2tvdXQgLWIgYnVtcApnaXQgYWRkIHB1YmxpYy5nbyBnby5tb2QKZ2l0IGNvbW1pdCAtcSAtbSAnQnVtcCBwdWJsaWMgdG8gZ28xLjE2JwpnaXQgcHVzaCAtcSBvcmlnaW4gYnVtcAo="><code class="language-.term1">$ cd /home/gopher/public
+$ git checkout -b bump
+Switched to a new branch &#39;bump&#39;
+$ git add public.go go.mod
+$ git commit -q -m &#39;Bump public to go1.16&#39;
+$ git push -q origin bump
+remote: 
+remote: Create a new pull request for &#39;bump&#39;:        
+remote:   https://&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;/compare/main...bump        
+remote: 
+remote: . Processing 1 references
+remote: Processed 1 references in total        
+</code></pre>
+
+
+Let's go back to our `gopher` module in `go` 1.15 and try to fetch
+the latest version of the `public` dependecy and see what happens
+
+<pre data-command-src="YWxpYXMgZ289Z28xMTUK"><code class="language-.term1">$ alias go=go115
+</code></pre>
+
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpjb2RlPSQoZ28gZ2V0IC11IC12IHt7ey5QVUJMSUN9fX1AYnVtcDsgZWNobyAkPykKWyAkY29kZSA9PSAyIF0gfHwgZmFsc2UK"><code class="language-.term1">$ cd /home/gopher/gopher
+$ code=$(go get -u -v &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@bump; echo $?)
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; bump =&gt; v0.0.0-20210510022530-3dbd6db9c7be
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210510022530-3dbd6db9c7be
+&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+# &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+$ [ $code == 2 ] || false
+</code></pre>
+
+
+As you can see, when trying to bump our `{{[ .gopher ]}}` project, we got an 
+error because in our case, we're still using `go` 1.15 in our project which
+doesn't support the new `io.Discard` package.
+
+How do we handle these situations where we shouldn't force our clients to update?
+The right approach to tackle this is by using `build tag` so our `public`
+clients can build their project regardless of the `go` version they're using
+
+
+### Adding `build` tags to our `public` project
+
+Let's go ahead and modify our `public` project so it now uses the 
+`// +build 1.16` tag.
+
+First we rollback the changes to our original file to keep using the `ioutil.Discard`
+pacage for `go` < 1.16 clients
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL3B1YmxpYw==" data-upload-src="cHVibGljLmdv:Ly8gK2J1aWxkICFnbzEuMTYKCnBhY2thZ2UgcHVibGljCgppbXBvcnQgKAogICAgImZtdCIKICAgICJpby9pb3V0aWwiCikKCmZ1bmMgRG9Tb21ldGhpbmcoKSB7CiAgICBmbXQuRnByaW50Zihpb3V0aWwuRGlzY2FyZCwgIlRoaXMgZG9lc24ndCBwcmludCBhbnl0aGluZyIpCn0=" data-upload-term=".term1"><code class="language-go">// +build !go1.16
+
+package public
+
+import (
+    &#34;fmt&#34;
+    &#34;io/ioutil&#34;
+)
+
+func DoSomething() &#123;
+    fmt.Fprintf(ioutil.Discard, &#34;This doesn&#39;t print anything&#34;)
+&#125;</code></pre>
+
+
+Additionally, we create a new file which has the correct build tag, so 
+newer clients can make use of the new package
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL3B1YmxpYw==" data-upload-src="cHVibGljXzExNi5nbw==:Ly8gK2J1aWxkIGdvLjEuMTYKCnBhY2thZ2UgcHVibGljCgppbXBvcnQgKAogICAgImZtdCIKICAgICJpbyIKKQoKZnVuYyBEb1NvbWV0aGluZygpIHsKICAgIGZtdC5GcHJpbnRmKGlvLkRpc2NhcmQsICJUaGlzIGRvZXNuJ3QgcHJpbnQgYW55dGhpbmciKQp9" data-upload-term=".term1"><code class="language-go">// +build go.1.16
+
+package public
+
+import (
+    &#34;fmt&#34;
+    &#34;io&#34;
+)
+
+func DoSomething() &#123;
+    fmt.Fprintf(io.Discard, &#34;This doesn&#39;t print anything&#34;)
+&#125;</code></pre>
+
+Let's now publish our fixed module
+
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL3B1YmxpYwpnaXQgY2hlY2tvdXQgLWIgYnVtcF9maXgKZ2l0IGFkZCBwdWJsaWMuZ28gcHVibGljXzExNi5nbyBnby5tb2QKZ2l0IGNvbW1pdCAtcSAtbSAnRml4IHB1YmxpYyBidW1wIHRvIGdvMS4xNicKZ2l0IHB1c2ggLXEgb3JpZ2luIGJ1bXBfZml4Cg=="><code class="language-.term1">$ cd /home/gopher/public
+$ git checkout -b bump_fix
+Switched to a new branch &#39;bump_fix&#39;
+$ git add public.go public_116.go go.mod
+$ git commit -q -m &#39;Fix public bump to go1.16&#39;
+$ git push -q origin bump_fix
+remote: 
+remote: Create a new pull request for &#39;bump_fix&#39;:        
+remote:   https://&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;/compare/main...bump_fix        
+remote: 
+remote: . Processing 1 references        
+remote: Processed 1 references in total        
+</code></pre>
+
+
+Now, we can go ahead and update our `gopher` without problems with the
+benefit that `go` 1.16 clients and future clients will be able to use make 
+use of the newer `go` features and packages.
+
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpnbyBnZXQgLXUgLXYge3t7LlBVQkxJQ319fUBidW1wX2ZpeAo="><code class="language-.term1">$ cd /home/gopher/gopher
+$ go get -u -v &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@bump_fix
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; bump_fix =&gt; v0.0.0-20210510022545-65e54e92a856
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210510022545-65e54e92a856
+&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+</code></pre>
+
+
+### Conclusion
+
+This guide has provided you with a brief introduction to handling private modules.
+
+As a next step you might like to consider:
+
+* [Developer tools as module dependencies](/tools-as-dependencies_go115_en/)
+* [How to use and tweak Staticcheck](/using-staticcheck_go115_en/)
+* [Installing Go](/installing-go_go115_en/)
+<script>let pageGuide="2021-05-02-build-flags-backwards-compatibility"; let pageLanguage="en"; let pageScenario="go115";</script>

--- a/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
+++ b/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
@@ -22,6 +22,14 @@ and at the same time you don't want to force downstream dependecies to upgrade. 
 conditional compilation through build tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
 package respectively.
 
+Here's a high level overview of the steps you'll accomplish following this guide:
+
+- Create a `public` module that contains and exports a `DoSomething()` function
+- Create a `gopher` module that uses the `public`module
+- Bump the `public` module to use `go` 1.16 features without any considerations
+- Try updating the `gopher` module and show the observed errors
+- Fix the `public` module by adding required buid tags.
+
 
 ### A simple go 1.15 program using ioutil.Discard
 

--- a/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
+++ b/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
@@ -170,13 +170,13 @@ run again:
 
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpHT1BST1hZPWRpcmVjdCBnbyBnZXQgLWQge3t7LlBVQkxJQ319fUBsYXRlc3QK"><code class="language-.term1">$ cd /home/gopher/gopher
 $ GOPROXY=direct go get -d &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@latest
-go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20210516082250-842dcc186154
-go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210516082250-842dcc186154
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20210517052223-fcd4ca0bf3d0
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210517052223-fcd4ca0bf3d0
 </code></pre>
 
 <pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .
 # &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
-../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
+../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
 </code></pre>
 
 As you can see, when trying to run our `gopher` project using the

--- a/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
+++ b/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
@@ -12,15 +12,15 @@ _By [Marcos Nils](https://twitter.com/marcosnils), [Docker Captain](https://www.
 
 Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features on the standard library.
 As the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
-new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `go:embed` directive amongst others. 
+new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `go:embed` directive amongst others.
 
 As a module author, how could I introduce these new features and at the same time provide some guarantees that
 my module can still support the last N releases of go?
 
 This guide explains how to deal with situations where you want to use new features of recent versions of `go`
-and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using 
+and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using
 conditional compilation through build tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
-package respectively. 
+package respectively.
 
 
 ### A simple go 1.15 program using ioutil.Discard
@@ -104,12 +104,16 @@ func main() &#123;
 </code></pre>
 
 
+Get the initial version of the `gopher` module:
+
+<pre data-command-src="Z28gZ2V0IC1kIHt7ey5QVUJMSUN9fX1AbGF0ZXN0Cg=="><code class="language-.term1">$ go get -d &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@latest
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20060102150405-abcedf12345
+</code></pre>
+
 Now, we'll run the `gopher` module `main` package:
 
 <pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .
-go: finding module for package &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
-go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210516021259-5911e81d2353
-go: found &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; in &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210516021259-5911e81d2353
 </code></pre>
 
 
@@ -141,41 +145,37 @@ func DoSomething() &#123;
 Now we're good to release a new version of our `public` module
 using the `go` 1.16 new package:
 
-<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL3B1YmxpYwpnaXQgY2hlY2tvdXQgLWIgYnVtcApnaXQgYWRkIHB1YmxpYy5nbyBnby5tb2QKZ2l0IGNvbW1pdCAtcSAtbSAnQnVtcCBwdWJsaWMgdG8gZ28xLjE2JwpnaXQgcHVzaCAtcSBvcmlnaW4gYnVtcAo="><code class="language-.term1">$ cd /home/gopher/public
-$ git checkout -b bump
-Switched to a new branch &#39;bump&#39;
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL3B1YmxpYwpnaXQgYWRkIHB1YmxpYy5nbyBnby5tb2QKZ2l0IGNvbW1pdCAtcSAtbSAnQnVtcCBwdWJsaWMgdG8gZ28xLjE2JwpnaXQgcHVzaCAtcSBvcmlnaW4gbWFpbgo="><code class="language-.term1">$ cd /home/gopher/public
 $ git add public.go go.mod
 $ git commit -q -m &#39;Bump public to go1.16&#39;
-$ git push -q origin bump
-remote: 
-remote: Create a new pull request for &#39;bump&#39;:        
-remote:   https://&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;/compare/main...bump        
-remote: 
-remote: . Processing 1 references
+$ git push -q origin main
+remote: . Processing 1 references        
 remote: Processed 1 references in total        
 </code></pre>
 
 
-Let's go back to our `gopher` module in `go` 1.15 and try to fetch
-the latest version of the `public` dependecy and see what happens
+Let's go back to our `gopher` module in `go` 1.15, fetch the latest
+version of the `public` dependecy and see what happens when we try and
+run again:
 
 <pre data-command-src="YWxpYXMgZ289Z28xMTUK"><code class="language-.term1">$ alias go=go115
 </code></pre>
 
-<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpjb2RlPSQoZ28gZ2V0IC11IC12IHt7ey5QVUJMSUN9fX1AYnVtcDsgZWNobyAkPykKWyAkY29kZSA9PSAyIF0gfHwgZmFsc2UK"><code class="language-.term1">$ cd /home/gopher/gopher
-$ code=$(go get -u -v &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@bump; echo $?)
-go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; bump =&gt; v0.0.0-20210516021314-e2f48657c61e
-go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210516021314-e2f48657c61e
-&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
-# &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
-../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
-$ [ $code == 2 ] || false
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpHT1BST1hZPWRpcmVjdCBnbyBnZXQgLWQge3t7LlBVQkxJQ319fUBsYXRlc3QK"><code class="language-.term1">$ cd /home/gopher/gopher
+$ GOPROXY=direct go get -d &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@latest
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20210516082250-842dcc186154
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210516082250-842dcc186154
 </code></pre>
 
+<pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .
+# &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
+../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
+</code></pre>
 
-As you can see, when trying to bump our `{{[ .gopher ]}}` project, we got an 
-error because in our case, we're still using `go` 1.15 in the gopher project which
-doesn't support the new `io.Discard` package.
+As you can see, when trying to run our `gopher` project using the
+latest `public`, we got an error because in our case, we're still using
+`go` 1.15 in the gopher project which doesn't support the new `io.Discard`
+package.
 
 How do we handle these situations where we shouldn't force our clients to update?
 The right approach to tackle this is by using [build constraints](https://pkg.go.dev/go/build#hdr-Build_Constraints) so our `public`
@@ -184,7 +184,7 @@ clients can build their project regardless of the `go` version they're using
 
 ### Adding `build` tags to our `public` project
 
-Let's go ahead and modify our `public` project so it now uses the 
+Let's go ahead and modify our `public` project so it now uses the
 `// +build 1.16` tag.
 
 First we rollback the changes to our original file to keep using the `ioutil.Discard`
@@ -203,8 +203,7 @@ func DoSomething() &#123;
     fmt.Fprintf(ioutil.Discard, &#34;This doesn&#39;t print anything&#34;)
 &#125;</code></pre>
 
-
-Additionally, we create a new file which has the correct build tag, so 
+Additionally, we create a new file which has the correct build tag, so
 newer clients can make use of the new package
 
 <pre data-upload-path="L2hvbWUvZ29waGVyL3B1YmxpYw==" data-upload-src="cHVibGljXzExNi5nbw==:Ly8gK2J1aWxkIGdvLjEuMTYKCnBhY2thZ2UgcHVibGljCgppbXBvcnQgKAogICAgImZtdCIKICAgICJpbyIKKQoKZnVuYyBEb1NvbWV0aGluZygpIHsKICAgIGZtdC5GcHJpbnRmKGlvLkRpc2NhcmQsICJUaGlzIGRvZXNuJ3QgcHJpbnQgYW55dGhpbmciKQp9" data-upload-term=".term1"><code class="language-go">// +build go.1.16
@@ -222,35 +221,35 @@ func DoSomething() &#123;
 
 Let's now publish our fixed module
 
-<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL3B1YmxpYwpnaXQgY2hlY2tvdXQgLWIgYnVtcF9maXgKZ2l0IGFkZCBwdWJsaWMuZ28gcHVibGljXzExNi5nbyBnby5tb2QKZ2l0IGNvbW1pdCAtcSAtbSAnRml4IHB1YmxpYyBidW1wIHRvIGdvMS4xNicKZ2l0IHB1c2ggLXEgb3JpZ2luIGJ1bXBfZml4Cg=="><code class="language-.term1">$ cd /home/gopher/public
-$ git checkout -b bump_fix
-Switched to a new branch &#39;bump_fix&#39;
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL3B1YmxpYwpnaXQgYWRkIHB1YmxpYy5nbyBwdWJsaWNfMTE2LmdvIGdvLm1vZApnaXQgY29tbWl0IC1xIC1tICdGaXggcHVibGljIGJ1bXAgdG8gZ28xLjE2JwpnaXQgcHVzaCAtcSBvcmlnaW4gbWFpbgo="><code class="language-.term1">$ cd /home/gopher/public
 $ git add public.go public_116.go go.mod
 $ git commit -q -m &#39;Fix public bump to go1.16&#39;
-$ git push -q origin bump_fix
-remote: 
-remote: Create a new pull request for &#39;bump_fix&#39;:        
-remote:   https://&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;/compare/main...bump_fix        
-remote: 
+$ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 </code></pre>
 
 
 Now, we can go ahead and update our `gopher` without problems with the
-benefit that `go` 1.16 clients and future clients will be able to use make 
+benefit that `go` 1.16 clients and future clients will be able to use make
 use of the newer `go` features and packages.
 
-<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpnbyBnZXQgLWQgLXYge3t7LlBVQkxJQ319fUBidW1wX2ZpeAo="><code class="language-.term1">$ cd /home/gopher/gopher
-$ go get -d -v &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@bump_fix
-go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; bump_fix =&gt; v0.0.0-20210516021327-c273d5742f90
-go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210516021327-c273d5742f90
+<pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpHT1BST1hZPWRpcmVjdCBnbyBnZXQgLWQge3t7LlBVQkxJQ319fUBsYXRlc3QK"><code class="language-.term1">$ cd /home/gopher/gopher
+$ GOPROXY=direct go get -d &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@latest
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20060102150405-abcedf12345
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
+</code></pre>
+
+<pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .
 </code></pre>
 
 
 ### Conclusion
 
-This guide has provided you with a brief introduction to handling private modules.
+This guide serves as an example on how to leverage on [build constraints](https://pkg.go.dev/go/build#hdr-Build_Constraints)
+to provide a backwards compatbile module to your clients. Build constraints are a very
+powerful pattern to achieve other tasks in `go`. We encourage the reader to check the official docs
+for further examples.
 
 As a next step you might like to consider:
 

--- a/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
+++ b/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
@@ -10,17 +10,16 @@ title: Using build flags for backwards compatibility
 
 _By [Marcos Nils](https://twitter.com/marcosnils), [Docker Captain](https://www.docker.com/captains/marcos-lilljedahl), Hashicorp Ambassador, Go developer, and co-creator of `play-with-go.dev`._
 
-Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features on the standard library.
-As the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
+Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features in the standard library.
+At the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
 new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `go:embed` directive amongst others.
 
 As a module author, how could I introduce these new features and at the same time provide some guarantees that
 my module can still support the last N releases of go?
 
 This guide explains how to deal with situations where you want to use new features of recent versions of `go`
-and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using
-conditional compilation through build tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
-package respectively.
+and at the same time you don't want to force downstream dependats to upgrade. In this case we'll be using
+conditional compilation through build tags in a real life scenario by using 1.16's new io.FS whilst retaining compatibility for users of `go` 1.15.
 
 Here's a high level overview of the steps you'll accomplish following this guide:
 

--- a/cue.mod/tests/eval.txt
+++ b/cue.mod/tests/eval.txt
@@ -297,6 +297,35 @@ Delims: ["{{{", "}}}"]
     Networks: ["playwithgo_pwg"]
     Env: []
 }
+"2021-05-02-build-flags-backwards-compatibility": {
+    Delims: ["{{{", "}}}"]
+    Presteps: [{
+        Package: "github.com/play-with-go/gitea"
+        Path:    "/newuser"
+        Args: {
+            Repos: [{
+                Pattern: "public"
+                Private: false
+                Var:     "PUBLIC"
+            }]
+        }
+    }]
+    Terminals: [{
+        Name:        "term1"
+        Description: "The main terminal"
+        Scenarios: {
+            go115: {
+                Image: "playwithgo/go1.15_1.16@sha256:38ee32afdd785e5f1d9e63033ce5d64cbd098207ed6506669105db97c2dbe9a1"
+            }
+        }
+    }]
+    Scenarios: [{
+        Name:        "go115"
+        Description: "Go 1.15"
+    }]
+    Networks: ["playwithgo_pwg"]
+    Env: []
+}
 "2021-05-06-gosheffield-demo": {
     Delims: ["{{{", "}}}"]
     Terminals: [{
@@ -383,6 +412,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     greeting_log_prefix: "greetings: "
     proxygolangorg: {
@@ -3711,6 +3741,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     hellomod: "hello"
     proxygolangorg: {
@@ -4115,6 +4146,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     proxygolangorg: {
         waitforcache: "1m"
@@ -4785,6 +4817,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     mod2_dir: "/home/gopher/mod2"
     proxygolangorg: {
@@ -5294,6 +5327,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     username: "{{{.GITEA_USERNAME}}}"
     proxygolangorg: {
@@ -5843,6 +5877,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     stringer_type_flag: "-type"
     proxygolangorg: {
@@ -7096,6 +7131,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     gopher_go: "gopher.go"
     proxygolangorg: {
@@ -9189,6 +9225,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     mktemp: "mktemp -d"
     proxygolangorg: {
@@ -9500,6 +9537,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     pets_mod: "pets"
     proxygolangorg: {
@@ -11219,6 +11257,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     go_help_modprivate: "go help module-private"
     proxygolangorg: {
@@ -12445,6 +12484,7 @@ Defs: {
         tag:      "git tag"
         revparse: "git rev-parse"
         branch:   "git branch"
+        checkout: "git checkout"
     }
     go_help_modsubdir: "go help module-subdir"
     proxygolangorg: {
@@ -13575,6 +13615,1123 @@ Steps: {
     }
 }
 Hash: "8ef9567dbd2ab217155604d5765fa9d19321015d41bc33452860bf698ad2c9d8"
+Delims: ["{{{", "}}}"]
+// ---
+Networks: ["playwithgo_pwg"]
+Delims: ["{{{", "}}}"]
+Presteps: [{
+    Package: "github.com/play-with-go/gitea"
+    Path:    "/newuser"
+    Args: {
+        Repos: [{
+            Var:     "PUBLIC"
+            Pattern: "public"
+            Private: false
+        }]
+    }
+}]
+Defs: {
+    go115:        "go115"
+    go116:        "go116"
+    public:       "public"
+    public_vcs:   "https://{{{.PUBLIC}}}.git"
+    public_mod:   "{{{.PUBLIC}}}"
+    public_dir:   "/home/gopher/public"
+    public_go:    "public.go"
+    public_go116: "public_116.go"
+    public_func:  "DoSomething()"
+    gopher:       "gopher"
+    gopher_vcs:   "https://gopher.git"
+    gopher_mod:   "gopher"
+    gopher_dir:   "/home/gopher/gopher"
+    gopher_go:    "gopher.go"
+    go_help_env:  "go help env"
+    pwg: {
+        gopher_live: "gopher.live"
+    }
+    cmdgo: {
+        modinit:     "go mod init"
+        modedit:     "go mod edit"
+        modtidy:     "go mod tidy"
+        test:        "go test"
+        run:         "go run"
+        get:         "go get"
+        list:        "go list"
+        install:     "go install"
+        generate:    "go generate"
+        env:         "go env"
+        help:        "go help"
+        build:       "go build"
+        version:     "go version"
+        vlatest:     "latest"
+        GO111MODULE: "GO111MODULE"
+        GOPROXY:     "GOPROXY"
+        GOPATH:      "GOPATH"
+        GOBIN:       "GOBIN"
+        GOENV:       "GOENV"
+        GONOPROXY:   "GONOPROXY"
+        GOSUMDB:     "GOSUMDB"
+        GONOSUMDB:   "GONOSUMDB"
+        GOPRIVATE:   "GOPRIVATE"
+    }
+    git: {
+        add:      "git add"
+        remote:   "git remote"
+        init:     "git init -q"
+        commit:   "git commit -q"
+        push:     "git push -q"
+        tag:      "git tag"
+        revparse: "git rev-parse"
+        branch:   "git branch"
+        checkout: "git checkout"
+    }
+    go_help_modprivate: "go help module-private"
+    proxygolangorg: {
+        waitforcache: "1m"
+    }
+}
+Scenarios: {
+    go115: {
+        Name:        string
+        Description: "Go 1.15"
+    }
+}
+Terminals: {
+    term1: {
+        Name:        string
+        Description: "The main terminal"
+        Scenarios: {
+            go115: {
+                Image: "playwithgo/go1.15_1.16@sha256:38ee32afdd785e5f1d9e63033ce5d64cbd098207ed6506669105db97c2dbe9a1"
+            }
+        }
+    }
+}
+Steps: {
+    go115version: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "go115 version"
+        InformationOnly: false
+        Terminal:        string
+    }
+    go116version: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "go116 version"
+        InformationOnly: false
+        Terminal:        string
+    }
+    go115default: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "alias go=go115"
+        InformationOnly: false
+        Terminal:        string
+    }
+    public_init: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            mkdir /home/gopher/public
+            cd /home/gopher/public
+            go mod init {{{.PUBLIC}}}
+            git init -q
+            git remote add origin https://{{{.PUBLIC}}}.git
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    public_go_initial: {
+        Target:   "/home/gopher/public/public.go"
+        Language: "go"
+        Name:     string
+        StepType: 3
+        Source: """
+            package public
+
+            import (
+                "fmt"
+                "io/ioutil"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+            }
+            """
+        Renderer: {
+            RendererType: 1
+        }
+        Terminal: string
+    }
+    public_initial_commit: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            git add public.go go.mod
+            git commit -q -m 'Initial commit of public module'
+            git push -q origin main
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    public_check_initial_porcelain: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+        InformationOnly: true
+        Terminal:        string
+    }
+    gopher_init: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            mkdir /home/gopher/gopher
+            cd /home/gopher/gopher
+            go mod init gopher
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    gopher_go_initial: {
+        Target:   "/home/gopher/gopher/gopher.go"
+        Language: "go"
+        Name:     string
+        StepType: 3
+        Source: """
+            package main
+
+            import (
+
+            "{{{.PUBLIC}}}"
+            )
+
+            func main() {
+                public.DoSomething()
+            }
+
+            """
+        Renderer: {
+            RendererType: 1
+        }
+        Terminal: string
+    }
+    gopher_get: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "go get -d {{{.PUBLIC}}}@latest"
+        InformationOnly: false
+        Terminal:        string
+    }
+    golist_gopher_1: {
+        Name:            string
+        StepType:        1
+        Source:          "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+        RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+        DoNotTrim:       false
+        InformationOnly: true
+        Terminal:        string
+    }
+    gopher_run: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "go run ."
+        InformationOnly: false
+        Terminal:        string
+    }
+    go116default: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "alias go=go116"
+        InformationOnly: false
+        Terminal:        string
+    }
+    public_bump_discard: {
+        Target:   "/home/gopher/public/public.go"
+        Language: "go"
+        Name:     string
+        StepType: 3
+        Source: """
+            package public
+
+            import (
+                "fmt"
+                "io"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(io.Discard, "This doesn't print anything")
+            }
+            """
+        Renderer: {
+            RendererType: 1
+        }
+        Terminal: string
+    }
+    public_bump_commit: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            cd /home/gopher/public
+            git add public.go go.mod
+            git commit -q -m 'Bump public to go1.16'
+            git push -q origin main
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    go115default1: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "alias go=go115"
+        InformationOnly: false
+        Terminal:        string
+    }
+    gopher_update: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            cd /home/gopher/gopher
+            GOPROXY=direct go get -d {{{.PUBLIC}}}@latest
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    gopher_run_fail: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "! go run ."
+        InformationOnly: false
+        Terminal:        string
+    }
+    public_rollback_mod: {
+        Target:   "/home/gopher/public/public.go"
+        Language: "go"
+        Name:     string
+        StepType: 3
+        Source: """
+            // +build !go1.16
+
+            package public
+
+            import (
+                "fmt"
+                "io/ioutil"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+            }
+            """
+        Renderer: {
+            RendererType: 1
+        }
+        Terminal: string
+    }
+    public_add_buildtag: {
+        Target:   "/home/gopher/public/public_116.go"
+        Language: "go"
+        Name:     string
+        StepType: 3
+        Source: """
+            // +build go.1.16
+
+            package public
+
+            import (
+                "fmt"
+                "io"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(io.Discard, "This doesn't print anything")
+            }
+            """
+        Renderer: {
+            RendererType: 1
+        }
+        Terminal: string
+    }
+    public_fix_commit: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            cd /home/gopher/public
+            git add public.go public_116.go go.mod
+            git commit -q -m 'Fix public bump to go1.16'
+            git push -q origin main
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    gopher_update_fix: {
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            cd /home/gopher/gopher
+            GOPROXY=direct go get -d {{{.PUBLIC}}}@latest
+            """
+        InformationOnly: false
+        Terminal:        string
+    }
+    golist_gopher_2: {
+        Name:            string
+        StepType:        1
+        Source:          "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+        RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+        DoNotTrim:       false
+        InformationOnly: true
+        Terminal:        string
+    }
+    gopher_run_fix: {
+        DoNotTrim:       false
+        Name:            string
+        StepType:        1
+        Source:          "go run ."
+        InformationOnly: false
+        Terminal:        string
+    }
+}
+// ---
+Presteps: [{
+    Package: "github.com/play-with-go/gitea"
+    Path:    "/newuser"
+    Args: {
+        Repos: [{
+            Pattern: "public"
+            Private: false
+            Var:     "PUBLIC"
+        }]
+    }
+    Version: """
+        {
+          "Path": "github.com/play-with-go/gitea/cmd/gitea",
+          "Main": {
+            "Path": "github.com/play-with-go/gitea",
+            "Version": "v0.0.0-20210430163339-b27dc21b6036",
+            "Sum": "h1:7wJ+VvtJk2GU9XtFGDeVwO6ohT8l5nu5h9A6YDCec+U=",
+            "Replace": null
+          },
+          "Deps": [
+            {
+              "Path": "code.gitea.io/sdk/gitea",
+              "Version": "v0.13.1",
+              "Sum": "h1:Y7bpH2iO6Q0KhhMJfjP/LZ0AmiYITeRQlCD8b0oYqhk=",
+              "Replace": null
+            },
+            {
+              "Path": "cuelang.org/go",
+              "Version": "v0.3.2",
+              "Sum": "h1:/Am5yFDwqnaEi+g942OPM1M4/qtfVSm49wtkQbeh5Z4=",
+              "Replace": null
+            },
+            {
+              "Path": "github.com/cockroachdb/apd/v2",
+              "Version": "v2.0.1",
+              "Sum": "h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWqLTE=",
+              "Replace": null
+            },
+            {
+              "Path": "github.com/emicklei/proto",
+              "Version": "v1.6.15",
+              "Sum": "h1:XbpwxmuOPrdES97FrSfpyy67SSCV/wBIKXqgJzh6hNw=",
+              "Replace": null
+            },
+            {
+              "Path": "github.com/hashicorp/go-version",
+              "Version": "v1.2.0",
+              "Sum": "h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=",
+              "Replace": null
+            },
+            {
+              "Path": "github.com/mpvl/unique",
+              "Version": "v0.0.0-20150818121801-cbe035fff7de",
+              "Sum": "h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=",
+              "Replace": null
+            },
+            {
+              "Path": "github.com/pkg/errors",
+              "Version": "v0.8.1",
+              "Sum": "h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=",
+              "Replace": null
+            },
+            {
+              "Path": "github.com/play-with-go/preguide",
+              "Version": "v0.0.2-0.20210430163307-e5ab271ba2e9",
+              "Sum": "h1:dpSLI117TKb8MdLknsUYbQjKJpP6jzBYpfKKVszCZNI=",
+              "Replace": null
+            },
+            {
+              "Path": "golang.org/x/crypto",
+              "Version": "v0.0.0-20200622213623-75b288015ac9",
+              "Sum": "h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=",
+              "Replace": null
+            },
+            {
+              "Path": "golang.org/x/net",
+              "Version": "v0.0.0-20201021035429-f5854403a974",
+              "Sum": "h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=",
+              "Replace": null
+            },
+            {
+              "Path": "golang.org/x/text",
+              "Version": "v0.3.3",
+              "Sum": "h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=",
+              "Replace": null
+            },
+            {
+              "Path": "golang.org/x/xerrors",
+              "Version": "v0.0.0-20200804184101-5ec99f83aff1",
+              "Sum": "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
+              "Replace": null
+            },
+            {
+              "Path": "gopkg.in/retry.v1",
+              "Version": "v1.0.3",
+              "Sum": "h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=",
+              "Replace": null
+            },
+            {
+              "Path": "gopkg.in/yaml.v3",
+              "Version": "v3.0.0-20200121175148-a6ecf24a6d71",
+              "Sum": "h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=",
+              "Replace": null
+            }
+          ]
+        }
+        """
+    Variables: ["GITEA_USERNAME", "GITEA_PRIV_KEY", "GITEA_PUB_KEY", "GITEA_KEYSCAN", "PUBLIC"]
+}]
+Terminals: [{
+    Name:        "term1"
+    Description: "The main terminal"
+    Scenarios: {
+        go115: {
+            Image: "playwithgo/go1.15_1.16@sha256:38ee32afdd785e5f1d9e63033ce5d64cbd098207ed6506669105db97c2dbe9a1"
+        }
+    }
+}]
+Scenarios: [{
+    Name:        "go115"
+    Description: "Go 1.15"
+}]
+Networks: ["playwithgo_pwg"]
+Env: []
+FilenameComment: false
+Steps: {
+    go115version: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "go115version"
+        Order:           0
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  false
+            CmdStr:   "go115 version"
+            ExitCode: 0
+            Output: """
+                go version go1.15.8 linux/amd64
+
+                """
+            ComparisonOutput: """
+                go version go1.15.8 linux/amd64
+
+                """
+        }]
+    }
+    go116version: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "go116version"
+        Order:           1
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  false
+            CmdStr:   "go116 version"
+            ExitCode: 0
+            Output: """
+                go version go1.16.3 linux/amd64
+
+                """
+            ComparisonOutput: """
+                go version go1.16.3 linux/amd64
+
+                """
+        }]
+    }
+    go115default: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "go115default"
+        Order:           2
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "alias go=go115"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+    public_init: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "public_init"
+        Order:           3
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "mkdir /home/gopher/public"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "cd /home/gopher/public"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "go mod init {{{.PUBLIC}}}"
+            ExitCode: 0
+            Output: """
+                go: creating new go.mod: module {{{.PUBLIC}}}
+
+                """
+            ComparisonOutput: """
+                go: creating new go.mod: module {{{.PUBLIC}}}
+
+                """
+        }, {
+            Negated:          false
+            CmdStr:           "git init -q"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "git remote add origin https://{{{.PUBLIC}}}.git"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+    public_go_initial: {
+        StepType: 2
+        Name:     "public_go_initial"
+        Order:    4
+        Terminal: "term1"
+        Language: "go"
+        Renderer: {
+            RendererType: 1
+        }
+        Source: """
+            package public
+
+            import (
+                "fmt"
+                "io/ioutil"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+            }
+            """
+        Target: "/home/gopher/public/public.go"
+    }
+    public_initial_commit: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "public_initial_commit"
+        Order:           5
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "git add public.go go.mod"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "git commit -q -m 'Initial commit of public module'"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "git push -q origin main"
+            ExitCode: 0
+            Output: """
+                remote: . Processing 1 references        
+                remote: Processed 1 references in total        
+
+                """
+            ComparisonOutput: """
+                remote: . Processing 1 references        
+                remote: Processed 1 references in total        
+
+                """
+        }]
+    }
+    public_check_initial_porcelain: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: true
+        Name:            "public_check_initial_porcelain"
+        Order:           6
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+    gopher_init: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_init"
+        Order:           7
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "mkdir /home/gopher/gopher"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "cd /home/gopher/gopher"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "go mod init gopher"
+            ExitCode: 0
+            Output: """
+                go: creating new go.mod: module gopher
+
+                """
+            ComparisonOutput: """
+                go: creating new go.mod: module gopher
+
+                """
+        }]
+    }
+    gopher_go_initial: {
+        StepType: 2
+        Name:     "gopher_go_initial"
+        Order:    8
+        Terminal: "term1"
+        Language: "go"
+        Renderer: {
+            RendererType: 1
+        }
+        Source: """
+            package main
+
+            import (
+
+            "{{{.PUBLIC}}}"
+            )
+
+            func main() {
+                public.DoSomething()
+            }
+
+            """
+        Target: "/home/gopher/gopher/gopher.go"
+    }
+    gopher_get: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_get"
+        Order:           9
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  false
+            CmdStr:   "go get -d {{{.PUBLIC}}}@latest"
+            ExitCode: 0
+            Output: """
+                go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+                go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+
+                """
+            ComparisonOutput: """
+
+                go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+                go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+                """
+        }]
+    }
+    golist_gopher_1: {
+        StepType:        1
+        RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+        DoNotTrim:       false
+        InformationOnly: true
+        Name:            "golist_gopher_1"
+        Order:           10
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  false
+            CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+            ExitCode: 0
+            Output: """
+                v0.0.0-20060102150405-abcedf12345
+
+                """
+            ComparisonOutput: """
+                v0.0.0-20060102150405-abcedf12345
+
+                """
+        }]
+    }
+    gopher_run: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_run"
+        Order:           11
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "go run ."
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+    go116default: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "go116default"
+        Order:           12
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "alias go=go116"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+    public_bump_discard: {
+        StepType: 2
+        Name:     "public_bump_discard"
+        Order:    13
+        Terminal: "term1"
+        Language: "go"
+        Renderer: {
+            RendererType: 1
+        }
+        Source: """
+            package public
+
+            import (
+                "fmt"
+                "io"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(io.Discard, "This doesn't print anything")
+            }
+            """
+        Target: "/home/gopher/public/public.go"
+    }
+    public_bump_commit: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "public_bump_commit"
+        Order:           14
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "cd /home/gopher/public"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "git add public.go go.mod"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "git commit -q -m 'Bump public to go1.16'"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "git push -q origin main"
+            ExitCode: 0
+            Output: """
+                remote: . Processing 1 references        
+                remote: Processed 1 references in total        
+
+                """
+            ComparisonOutput: """
+                remote: . Processing 1 references        
+                remote: Processed 1 references in total        
+
+                """
+        }]
+    }
+    go115default1: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "go115default1"
+        Order:           15
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "alias go=go115"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+    gopher_update: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_update"
+        Order:           16
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "cd /home/gopher/gopher"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
+            ExitCode: 0
+            Output: """
+                go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
+                go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
+
+                """
+            ComparisonOutput: """
+
+                go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
+                go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
+                """
+        }]
+    }
+    gopher_run_fail: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_run_fail"
+        Order:           17
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  true
+            CmdStr:   "go run ."
+            ExitCode: 2
+            Output: """
+                # {{{.PUBLIC}}}
+                ../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+
+                """
+            ComparisonOutput: """
+                # {{{.PUBLIC}}}
+                ../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+
+                """
+        }]
+    }
+    public_rollback_mod: {
+        StepType: 2
+        Name:     "public_rollback_mod"
+        Order:    18
+        Terminal: "term1"
+        Language: "go"
+        Renderer: {
+            RendererType: 1
+        }
+        Source: """
+            // +build !go1.16
+
+            package public
+
+            import (
+                "fmt"
+                "io/ioutil"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+            }
+            """
+        Target: "/home/gopher/public/public.go"
+    }
+    public_add_buildtag: {
+        StepType: 2
+        Name:     "public_add_buildtag"
+        Order:    19
+        Terminal: "term1"
+        Language: "go"
+        Renderer: {
+            RendererType: 1
+        }
+        Source: """
+            // +build go.1.16
+
+            package public
+
+            import (
+                "fmt"
+                "io"
+            )
+
+            func DoSomething() {
+                fmt.Fprintf(io.Discard, "This doesn't print anything")
+            }
+            """
+        Target: "/home/gopher/public/public_116.go"
+    }
+    public_fix_commit: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "public_fix_commit"
+        Order:           20
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "cd /home/gopher/public"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "git add public.go public_116.go go.mod"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:          false
+            CmdStr:           "git commit -q -m 'Fix public bump to go1.16'"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "git push -q origin main"
+            ExitCode: 0
+            Output: """
+                remote: . Processing 1 references        
+                remote: Processed 1 references in total        
+
+                """
+            ComparisonOutput: """
+                remote: . Processing 1 references        
+                remote: Processed 1 references in total        
+
+                """
+        }]
+    }
+    gopher_update_fix: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_update_fix"
+        Order:           21
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "cd /home/gopher/gopher"
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }, {
+            Negated:  false
+            CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
+            ExitCode: 0
+            Output: """
+                go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+                go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+
+                """
+            ComparisonOutput: """
+
+                go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+                go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+                """
+        }]
+    }
+    golist_gopher_2: {
+        StepType:        1
+        RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+        DoNotTrim:       false
+        InformationOnly: true
+        Name:            "golist_gopher_2"
+        Order:           22
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  false
+            CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+            ExitCode: 0
+            Output: """
+                v0.0.0-20060102150405-abcedf12345
+
+                """
+            ComparisonOutput: """
+                v0.0.0-20060102150405-abcedf12345
+
+                """
+        }]
+    }
+    gopher_run_fix: {
+        StepType:        1
+        DoNotTrim:       false
+        InformationOnly: false
+        Name:            "gopher_run_fix"
+        Order:           23
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:          false
+            CmdStr:           "go run ."
+            ExitCode:         0
+            Output:           ""
+            ComparisonOutput: ""
+        }]
+    }
+}
+Hash: "087597cb2f6d2340581cfe8324db65938ef581566661e67cf19e93cffaefbf16"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]

--- a/guide.cue
+++ b/guide.cue
@@ -57,6 +57,7 @@ _#commonDefs: {
 		tag:      "git tag"
 		revparse: "git rev-parse"
 		branch:   "git branch"
+		checkout: "git checkout"
 	}
 	proxygolangorg: {
 		waitforcache: "1m" // value passed to Unix sleep

--- a/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
@@ -8,17 +8,16 @@ category: Next steps
 
 _By [Marcos Nils](https://twitter.com/marcosnils), [Docker Captain](https://www.docker.com/captains/marcos-lilljedahl), Hashicorp Ambassador, Go developer, and co-creator of `play-with-go.dev`._
 
-Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features on the standard library.
-As the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
+Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features in the standard library.
+At the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
 new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `go:embed` directive amongst others.
 
 As a module author, how could I introduce these new features and at the same time provide some guarantees that
 my module can still support the last N releases of go?
 
 This guide explains how to deal with situations where you want to use new features of recent versions of `go`
-and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using
-conditional compilation through build tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
-package respectively.
+and at the same time you don't want to force downstream dependats to upgrade. In this case we'll be using
+conditional compilation through build tags in a real life scenario by using 1.16's new io.FS whilst retaining compatibility for users of `go` 1.15.
 
 Here's a high level overview of the steps you'll accomplish following this guide:
 

--- a/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
@@ -10,23 +10,20 @@ _By [Marcos Nils](https://twitter.com/marcosnils), [Docker Captain](https://www.
 
 Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features on the standard library.
 As the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
-new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `embed` directive amongst others. 
+new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `go:embed` directive amongst others. 
 
-It's usually common to see developers wanting to adopt all these new features and refactor their code so they can take
-advantage of these interfaces to make their applications and libraries more modular, testable and sometimes
-even more performant. However, it's important to understand how these changes, if not done carefuly, can
-sometimes break downstream dependencies given that in the case of `go`, when you're importing a third party module,
-you're forced to build your project with the latest version of the complete dependency tree. 
+As a module author, how could I introduce these new features and at the same time provide some guarantees that
+my module can still support the last N releases of go?
 
 This guide explains how to deal with situations where you want to use new features of recent versions of `go`
 and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using 
-conditional compilation through `go build` tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
+conditional compilation through build tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
 package respectively. 
 
 
 ### A simple go 1.15 program using ioutil.Discard
 
-Let's start by checking our current `go` 1.15 version:
+Verifying that we're using `go` 1.15 version:
 
 {{{ step "go115version" }}}
 
@@ -101,11 +98,11 @@ the latest version of the `{{{ .public }}}` dependecy and see what happens
 
 
 As you can see, when trying to bump our `{{[ .gopher ]}}` project, we got an 
-error because in our case, we're still using `go` 1.15 in our project which
+error because in our case, we're still using `go` 1.15 in the gopher project which
 doesn't support the new `io.Discard` package.
 
 How do we handle these situations where we shouldn't force our clients to update?
-The right approach to tackle this is by using `build tag` so our `{{{ .public }}}`
+The right approach to tackle this is by using [build constraints](https://pkg.go.dev/go/build#hdr-Build_Constraints) so our `{{{ .public }}}`
 clients can build their project regardless of the `go` version they're using
 
 
@@ -139,10 +136,12 @@ use of the newer `go` features and packages.
 
 ### Conclusion
 
-This guide has provided you with a brief introduction to handling private modules.
+This guide serves as an example on how to leverage on [build constraints](https://pkg.go.dev/go/build#hdr-Build_Constraints)
+to provide a backwards compatbile module to your clients. Build constraints are a very 
+powerful pattern to achieve other tasks in `go`. We encourage the reader to check the official docs
+for further examples.
 
 As a next step you might like to consider:
 
-* [Developer tools as module dependencies](/tools-as-dependencies_go115_en/)
-* [How to use and tweak Staticcheck](/using-staticcheck_go115_en/)
-* [Installing Go](/installing-go_go115_en/)
+* [Wokring with private modules](/working-with-private-modules_go115_en/)
+* [Retract module versions](/retract-module-versions_go116_en/)

--- a/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
@@ -20,6 +20,14 @@ and at the same time you don't want to force downstream dependecies to upgrade. 
 conditional compilation through build tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
 package respectively.
 
+Here's a high level overview of the steps you'll accomplish following this guide:
+
+- Create a `{{{ .public }}}` module that contains and exports a `{{{ .public_func }}}` function
+- Create a `{{{ .gopher }}}` module that uses the `{{{ .public }}}`module
+- Bump the `{{{ .public }}}` module to use `go` 1.16 features without any considerations
+- Try updating the `{{{ .gopher }}}` module and show the observed errors
+- Fix the `{{{ .public }}}` module by adding required buid tags.
+
 
 ### A simple go 1.15 program using ioutil.Discard
 

--- a/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/en.markdown
@@ -1,0 +1,148 @@
+---
+layout: post
+title:  "Using build flags for backwards compatibility"
+excerpt: "How to leverage go build flags to avoid breaking downstream projects "
+difficulty: Intermediate
+category: Next steps
+---
+
+_By [Marcos Nils](https://twitter.com/marcosnils), [Docker Captain](https://www.docker.com/captains/marcos-lilljedahl), Hashicorp Ambassador, Go developer, and co-creator of `play-with-go.dev`._
+
+Sometimes, when a new `go` version is released, it also ships with a bunch of changes and really interesting features on the standard library.
+As the time of this article, [go 1.16](https://golang.org/doc/go1.16) has been released around two months ago which introduces some changes and
+new features into the [core library](https://golang.org/doc/go1.16#library) like the new `io.FS` interface, the `embed` directive amongst others. 
+
+It's usually common to see developers wanting to adopt all these new features and refactor their code so they can take
+advantage of these interfaces to make their applications and libraries more modular, testable and sometimes
+even more performant. However, it's important to understand how these changes, if not done carefuly, can
+sometimes break downstream dependencies given that in the case of `go`, when you're importing a third party module,
+you're forced to build your project with the latest version of the complete dependency tree. 
+
+This guide explains how to deal with situations where you want to use new features of recent versions of `go`
+and at the same time you don't want to force downstream dependecies to upgrade. In this case we'll be using 
+conditional compilation through `go build` tags in a real case scenario by using `go` 1.15 and 1.16 new `io.FS`
+package respectively. 
+
+
+### A simple go 1.15 program using ioutil.Discard
+
+Let's start by checking our current `go` 1.15 version:
+
+{{{ step "go115version" }}}
+
+Now, we'll also check that we have `go` 1.16 installed as well:
+
+{{{ step "go116version" }}}
+
+
+We'll start by setting `go` 1.15 as the default working version:
+
+{{{ step "go115default" }}}
+
+Start by a new `public` module:
+
+{{{ step "public_init" }}}
+
+Now, we'll upload a simple `go` program that uses 1.15 `ioutil.Discard` in a public function:
+
+Create an initial version of the `{{{ .public_func }}}` in `{{{ .public_go }}}`:
+
+{{{ step "public_go_initial" }}}
+
+Commit and push this initial version:
+
+{{{ step "public_initial_commit" }}}
+
+### The `{{{ .gopher }}}` module
+
+Now create a `{{{ .gopher }}}` module to try out the `{{{ .public }}}` module. Unlike
+the `{{{ .public }}}` module, you will not publish the `{{{ .gopher }}}` module; it
+will be local only:
+
+{{{ step "gopher_init" }}}
+
+Create an initial version of a `main` package that uses the previous public module, in `{{{ .gopher_go }}}`:
+
+{{{ step "gopher_go_initial" }}}
+
+
+Now, we'll run the `{{{ .gopher }}}` module `main` package:
+
+{{{ step "gopher_run" }}}
+
+
+### Bumping the `{{{ .public }}}` dependency to `go` 1.16
+
+`Go` 1.16 has been released, and as good developers we want to refactor our
+code so it uses the new `io.Discard` variable instead of the deprecated `ioutil` one.
+
+
+First, we set our `go` version to 1.16:
+
+{{{ step "go116default" }}}
+
+Now, we change our original `{{{ .public }}}` module to use the new variable.
+
+{{{ step "public_bump_discard"}}}
+
+
+Now we're good to release a new version of our `{{{ .public }}}` module
+using the `go` 1.16 new package:
+
+{{{ step "public_bump_commit"}}}
+
+
+Let's go back to our `{{{ .gopher }}}` module in `go` 1.15 and try to fetch
+the latest version of the `{{{ .public }}}` dependecy and see what happens
+
+{{{ step "go115default1" }}}
+
+{{{ step "gopher_update_fail" }}}
+
+
+As you can see, when trying to bump our `{{[ .gopher ]}}` project, we got an 
+error because in our case, we're still using `go` 1.15 in our project which
+doesn't support the new `io.Discard` package.
+
+How do we handle these situations where we shouldn't force our clients to update?
+The right approach to tackle this is by using `build tag` so our `{{{ .public }}}`
+clients can build their project regardless of the `go` version they're using
+
+
+### Adding `build` tags to our `{{{ .public }}}` project
+
+Let's go ahead and modify our `{{{ .public }}}` project so it now uses the 
+`// +build 1.16` tag.
+
+First we rollback the changes to our original file to keep using the `ioutil.Discard`
+pacage for `go` < 1.16 clients
+
+{{{ step "public_rollback_mod" }}}
+
+
+Additionally, we create a new file which has the correct build tag, so 
+newer clients can make use of the new package
+
+{{{ step "public_add_buildtag" }}}
+
+Let's now publish our fixed module
+
+{{{ step "public_fix_commit"}}}
+
+
+Now, we can go ahead and update our `{{{ .gopher }}}` without problems with the
+benefit that `go` 1.16 clients and future clients will be able to use make 
+use of the newer `go` features and packages.
+
+{{{ step "gopher_update_ok" }}}
+
+
+### Conclusion
+
+This guide has provided you with a brief introduction to handling private modules.
+
+As a next step you might like to consider:
+
+* [Developer tools as module dependencies](/tools-as-dependencies_go115_en/)
+* [How to use and tweak Staticcheck](/using-staticcheck_go115_en/)
+* [Installing Go](/installing-go_go115_en/)

--- a/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
@@ -46,8 +46,8 @@ func main() {
 EOD
 $ go run .
 go: finding module for package {{{.PUBLIC}}}
-go: downloading {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
-go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+go: downloading {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
+go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
 $ alias go=go116
 $ cat <<EOD > /home/gopher/public/public.go
 package public
@@ -76,11 +76,11 @@ remote: Processed 1 references in total
 $ alias go=go115
 $ cd /home/gopher/gopher
 $ code=$(go get -u -v {{{.PUBLIC}}}@bump; echo $?)
-go: {{{.PUBLIC}}} bump => v0.0.0-20210510022530-3dbd6db9c7be
-go: downloading {{{.PUBLIC}}} v0.0.0-20210510022530-3dbd6db9c7be
+go: {{{.PUBLIC}}} bump => v0.0.0-20210516021314-e2f48657c61e
+go: downloading {{{.PUBLIC}}} v0.0.0-20210516021314-e2f48657c61e
 {{{.PUBLIC}}}
 # {{{.PUBLIC}}}
-../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
 $ [ $code == 2 ] || false
 $ cat <<EOD > /home/gopher/public/public.go
 // +build !go1.16
@@ -123,7 +123,6 @@ remote:
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 $ cd /home/gopher/gopher
-$ go get -u -v {{{.PUBLIC}}}@bump_fix
-go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210510022545-65e54e92a856
-go: downloading {{{.PUBLIC}}} v0.0.0-20210510022545-65e54e92a856
-{{{.PUBLIC}}}
+$ go get -d -v {{{.PUBLIC}}}@bump_fix
+go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210516021327-c273d5742f90
+go: downloading {{{.PUBLIC}}} v0.0.0-20210516021327-c273d5742f90

--- a/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
@@ -72,11 +72,11 @@ remote: Processed 1 references in total
 $ alias go=go115
 $ cd /home/gopher/gopher
 $ GOPROXY=direct go get -d {{{.PUBLIC}}}@latest
-go: {{{.PUBLIC}}} latest => v0.0.0-20210516082250-842dcc186154
-go: downloading {{{.PUBLIC}}} v0.0.0-20210516082250-842dcc186154
+go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
+go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
 $ go run .
 # {{{.PUBLIC}}}
-../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
+../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
 $ cat <<EOD > /home/gopher/public/public.go
 // +build !go1.16
 

--- a/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
@@ -1,0 +1,129 @@
+$ go115 version
+go version go1.15.8 linux/amd64
+$ go116 version
+go version go1.16.3 linux/amd64
+$ alias go=go115
+$ mkdir /home/gopher/public
+$ cd /home/gopher/public
+$ go mod init {{{.PUBLIC}}}
+go: creating new go.mod: module {{{.PUBLIC}}}
+$ git init -q
+$ git remote add origin https://{{{.PUBLIC}}}.git
+$ cat <<EOD > /home/gopher/public/public.go
+package public
+
+import (
+    "fmt"
+    "io/ioutil"
+)
+
+func DoSomething() {
+    fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+}
+EOD
+$ git add public.go go.mod
+$ git commit -q -m 'Initial commit of public module'
+$ git push -q origin main
+remote: . Processing 1 references        
+remote: Processed 1 references in total        
+$ [ "$(git status --porcelain)" == "" ] || (git status && false)
+$ mkdir /home/gopher/gopher
+$ cd /home/gopher/gopher
+$ go mod init gopher
+go: creating new go.mod: module gopher
+$ cat <<EOD > /home/gopher/gopher/gopher.go
+package main
+
+import (
+
+"{{{.PUBLIC}}}"
+)
+
+func main() {
+    public.DoSomething()
+}
+
+EOD
+$ go run .
+go: finding module for package {{{.PUBLIC}}}
+go: downloading {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+$ alias go=go116
+$ cat <<EOD > /home/gopher/public/public.go
+package public
+
+import (
+    "fmt"
+    "io"
+)
+
+func DoSomething() {
+    fmt.Fprintf(io.Discard, "This doesn't print anything")
+}
+EOD
+$ cd /home/gopher/public
+$ git checkout -b bump
+Switched to a new branch 'bump'
+$ git add public.go go.mod
+$ git commit -q -m 'Bump public to go1.16'
+$ git push -q origin bump
+remote: 
+remote: Create a new pull request for 'bump':        
+remote:   https://{{{.PUBLIC}}}/compare/main...bump        
+remote: 
+remote: . Processing 1 references
+remote: Processed 1 references in total        
+$ alias go=go115
+$ cd /home/gopher/gopher
+$ code=$(go get -u -v {{{.PUBLIC}}}@bump; echo $?)
+go: {{{.PUBLIC}}} bump => v0.0.0-20210510022530-3dbd6db9c7be
+go: downloading {{{.PUBLIC}}} v0.0.0-20210510022530-3dbd6db9c7be
+{{{.PUBLIC}}}
+# {{{.PUBLIC}}}
+../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+$ [ $code == 2 ] || false
+$ cat <<EOD > /home/gopher/public/public.go
+// +build !go1.16
+
+package public
+
+import (
+    "fmt"
+    "io/ioutil"
+)
+
+func DoSomething() {
+    fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+}
+EOD
+$ cat <<EOD > /home/gopher/public/public_116.go
+// +build go.1.16
+
+package public
+
+import (
+    "fmt"
+    "io"
+)
+
+func DoSomething() {
+    fmt.Fprintf(io.Discard, "This doesn't print anything")
+}
+EOD
+$ cd /home/gopher/public
+$ git checkout -b bump_fix
+Switched to a new branch 'bump_fix'
+$ git add public.go public_116.go go.mod
+$ git commit -q -m 'Fix public bump to go1.16'
+$ git push -q origin bump_fix
+remote: 
+remote: Create a new pull request for 'bump_fix':        
+remote:   https://{{{.PUBLIC}}}/compare/main...bump_fix        
+remote: 
+remote: . Processing 1 references        
+remote: Processed 1 references in total        
+$ cd /home/gopher/gopher
+$ go get -u -v {{{.PUBLIC}}}@bump_fix
+go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210510022545-65e54e92a856
+go: downloading {{{.PUBLIC}}} v0.0.0-20210510022545-65e54e92a856
+{{{.PUBLIC}}}

--- a/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
@@ -44,10 +44,12 @@ func main() {
 }
 
 EOD
+$ go get -d {{{.PUBLIC}}}@latest
+go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+$ go list -m -f {{.Version}} {{{.PUBLIC}}}
+v0.0.0-20060102150405-abcedf12345
 $ go run .
-go: finding module for package {{{.PUBLIC}}}
-go: downloading {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
-go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
 $ alias go=go116
 $ cat <<EOD > /home/gopher/public/public.go
 package public
@@ -62,26 +64,19 @@ func DoSomething() {
 }
 EOD
 $ cd /home/gopher/public
-$ git checkout -b bump
-Switched to a new branch 'bump'
 $ git add public.go go.mod
 $ git commit -q -m 'Bump public to go1.16'
-$ git push -q origin bump
-remote: 
-remote: Create a new pull request for 'bump':        
-remote:   https://{{{.PUBLIC}}}/compare/main...bump        
-remote: 
-remote: . Processing 1 references
+$ git push -q origin main
+remote: . Processing 1 references        
 remote: Processed 1 references in total        
 $ alias go=go115
 $ cd /home/gopher/gopher
-$ code=$(go get -u -v {{{.PUBLIC}}}@bump; echo $?)
-go: {{{.PUBLIC}}} bump => v0.0.0-20210516021314-e2f48657c61e
-go: downloading {{{.PUBLIC}}} v0.0.0-20210516021314-e2f48657c61e
-{{{.PUBLIC}}}
+$ GOPROXY=direct go get -d {{{.PUBLIC}}}@latest
+go: {{{.PUBLIC}}} latest => v0.0.0-20210516082250-842dcc186154
+go: downloading {{{.PUBLIC}}} v0.0.0-20210516082250-842dcc186154
+$ go run .
 # {{{.PUBLIC}}}
-../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
-$ [ $code == 2 ] || false
+../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
 $ cat <<EOD > /home/gopher/public/public.go
 // +build !go1.16
 
@@ -111,18 +106,15 @@ func DoSomething() {
 }
 EOD
 $ cd /home/gopher/public
-$ git checkout -b bump_fix
-Switched to a new branch 'bump_fix'
 $ git add public.go public_116.go go.mod
 $ git commit -q -m 'Fix public bump to go1.16'
-$ git push -q origin bump_fix
-remote: 
-remote: Create a new pull request for 'bump_fix':        
-remote:   https://{{{.PUBLIC}}}/compare/main...bump_fix        
-remote: 
+$ git push -q origin main
 remote: . Processing 1 references        
 remote: Processed 1 references in total        
 $ cd /home/gopher/gopher
-$ go get -d -v {{{.PUBLIC}}}@bump_fix
-go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210516021327-c273d5742f90
-go: downloading {{{.PUBLIC}}} v0.0.0-20210516021327-c273d5742f90
+$ GOPROXY=direct go get -d {{{.PUBLIC}}}@latest
+go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+$ go list -m -f {{.Version}} {{{.PUBLIC}}}
+v0.0.0-20060102150405-abcedf12345
+$ go run .

--- a/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
@@ -39,7 +39,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: "lala"
+	Scenarios: go115: Image: "playwithgo/go1.15_1.16@sha256:6cea9fd5d2b1316120a40e7d8c2c9e0db0a408bcb80ffbaad36238cf066298ee"
 }
 
 Steps: go115version: preguide.#Command & {
@@ -56,7 +56,7 @@ Steps: go116version: preguide.#Command & {
 
 Steps: go115default: preguide.#Command & {
 	Source: """
-		alias go=\(Defs.go115) 
+		alias go=\(Defs.go115)
 		"""
 }
 
@@ -126,6 +126,20 @@ func main() {
 """#
 }
 
+Steps: gopher_get: preguide.#Command & {
+	Source: """
+\(Defs.cmdgo.get) -d \(Defs.public_mod)@latest
+"""
+}
+
+Steps: golist_gopher_1: preguide.#Command & {
+	InformationOnly: true
+	RandomReplace:   "v0.0.0-\(_#StablePsuedoversionSuffix)"
+	Source:          """
+   go list -m -f {{.Version}} \(Defs.public_mod)
+   """
+}
+
 Steps: gopher_run: preguide.#Command & {
 	Source: """
 \(Defs.cmdgo.run) .
@@ -134,7 +148,7 @@ Steps: gopher_run: preguide.#Command & {
 
 Steps: go116default: preguide.#Command & {
 	Source: """
-alias go=\(Defs.go116) 
+alias go=\(Defs.go116)
 """
 }
 
@@ -157,27 +171,28 @@ func \#(Defs.public_func) {
 Steps: public_bump_commit: preguide.#Command & {
 	Source: """
 cd \(Defs.public_dir)
-\(Defs.git.checkout) -b bump
 \(Defs.git.add) \(Defs.public_go) go.mod
 \(Defs.git.commit) -m 'Bump \(Defs.public) to go1.16'
-\(Defs.git.push) origin bump
+\(Defs.git.push) origin main
 """
 }
 
 Steps: go115default1: preguide.#Command & {
 	Source: """
-		alias go=\(Defs.go115) 
+		alias go=\(Defs.go115)
 		"""
 }
 
-Steps: gopher_update_fail: preguide.#Command & {
+Steps: gopher_update: preguide.#Command & {
 	Source: """
 cd \(Defs.gopher_dir)
-# We launch this in a subshell to assert the status code
-code=$(\(Defs.cmdgo.get) -u -v \(Defs.public_mod)@bump; echo $?)
+GOPROXY=direct \(Defs.cmdgo.get) -d \(Defs.public_mod)@latest
+"""
+}
 
-# Assert that status code is correct or fail
-[ $code == 2 ] || false
+Steps: gopher_run_fail: preguide.#Command & {
+	Source: """
+! \(Defs.cmdgo.run) .
 """
 }
 
@@ -220,16 +235,29 @@ func \#(Defs.public_func) {
 Steps: public_fix_commit: preguide.#Command & {
 	Source: """
 cd \(Defs.public_dir)
-\(Defs.git.checkout) -b bump_fix
 \(Defs.git.add) \(Defs.public_go) \(Defs.public_go116) go.mod
 \(Defs.git.commit) -m 'Fix \(Defs.public) bump to go1.16'
-\(Defs.git.push) origin bump_fix
+\(Defs.git.push) origin main
 """
 }
 
-Steps: gopher_update_ok: preguide.#Command & {
+Steps: gopher_update_fix: preguide.#Command & {
 	Source: """
 cd \(Defs.gopher_dir)
-\(Defs.cmdgo.get) -d -v \(Defs.public_mod)@bump_fix
+GOPROXY=direct \(Defs.cmdgo.get) -d \(Defs.public_mod)@latest
+"""
+}
+
+Steps: golist_gopher_2: preguide.#Command & {
+	InformationOnly: true
+	RandomReplace:   "v0.0.0-\(_#StablePsuedoversionSuffix)"
+	Source:          """
+   go list -m -f {{.Version}} \(Defs.public_mod)
+   """
+}
+
+Steps: gopher_run_fix: preguide.#Command & {
+	Source: """
+\(Defs.cmdgo.run) .
 """
 }

--- a/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
@@ -230,6 +230,6 @@ cd \(Defs.public_dir)
 Steps: gopher_update_ok: preguide.#Command & {
 	Source: """
 cd \(Defs.gopher_dir)
-\(Defs.cmdgo.get) -u -v \(Defs.public_mod)@bump_fix
+\(Defs.cmdgo.get) -d -v \(Defs.public_mod)@bump_fix
 """
 }

--- a/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
@@ -1,0 +1,235 @@
+package guide
+
+import (
+	"github.com/play-with-go/gitea"
+	"github.com/play-with-go/preguide"
+)
+
+Presteps: [gitea.#PrestepNewUser & {
+	Args: {
+		Repos: [
+			{Var: "PUBLIC", Pattern: "public"},
+		]
+	}
+}]
+
+Defs: {
+	_#commonDefs
+	go115:              "go115"
+	go116:              "go116"
+	public:             "public"
+	public_vcs:         "https://\(public_mod).git"
+	public_mod:         "{{{.PUBLIC}}}"
+	public_dir:         "/home/gopher/\(public)"
+	public_go:          "\(public).go"
+	public_go116:       "\(public)_116.go"
+	public_func:        "DoSomething()"
+	gopher:             "gopher"
+	gopher_vcs:         "https://\(gopher_mod).git"
+	gopher_mod:         gopher
+	gopher_dir:         "/home/gopher/\(gopher)"
+	gopher_go:          "\(gopher).go"
+	go_help_env:        "\(_#commonDefs.cmdgo.help) env"
+	go_help_modprivate: "\(_#commonDefs.cmdgo.help) module-private"
+}
+
+Scenarios: go115: preguide.#Scenario & {
+	Description: "Go 1.15"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go115: Image: "lala"
+}
+
+Steps: go115version: preguide.#Command & {
+	Source: """
+		\(Defs.go115) version
+		"""
+}
+
+Steps: go116version: preguide.#Command & {
+	Source: """
+		\(Defs.go116) version
+		"""
+}
+
+Steps: go115default: preguide.#Command & {
+	Source: """
+		alias go=\(Defs.go115) 
+		"""
+}
+
+Steps: public_init: preguide.#Command & {
+	Source: """
+		mkdir \(Defs.public_dir)
+		cd \(Defs.public_dir)
+		\(Defs.cmdgo.modinit) \(Defs.public_mod)
+		\(Defs.git.init)
+		\(Defs.git.remote) add origin \(Defs.public_vcs)
+		"""
+}
+
+Steps: public_go_initial: preguide.#Upload & {
+	Target: "\(Defs.public_dir)/\(Defs.public_go)"
+	Source: #"""
+package \#(Defs.public)
+
+import (
+    "fmt"
+    "io/ioutil"
+)
+
+func \#(Defs.public_func) {
+    fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+}
+"""#
+}
+
+Steps: public_initial_commit: preguide.#Command & {
+	Source: """
+\(Defs.git.add) \(Defs.public_go) go.mod
+\(Defs.git.commit) -m 'Initial commit of \(Defs.public) module'
+\(Defs.git.push) origin main
+"""
+}
+
+Steps: public_check_initial_porcelain: preguide.#Command & {
+	InformationOnly: true
+	Source: """
+		[ "$(git status --porcelain)" == "" ] || (git status && false)
+		"""
+}
+
+Steps: gopher_init: preguide.#Command & {
+	Source: """
+mkdir \(Defs.gopher_dir)
+cd \(Defs.gopher_dir)
+\(Defs.cmdgo.modinit) \(Defs.gopher)
+"""
+}
+
+Steps: gopher_go_initial: preguide.#Upload & {
+	Target: "\(Defs.gopher_dir)/\(Defs.gopher_go)"
+	Source: #"""
+package main
+
+import (
+
+"\#(Defs.public_mod)"
+)
+
+func main() {
+    \#(Defs.public).\#(Defs.public_func)
+}
+
+"""#
+}
+
+Steps: gopher_run: preguide.#Command & {
+	Source: """
+\(Defs.cmdgo.run) .
+"""
+}
+
+Steps: go116default: preguide.#Command & {
+	Source: """
+alias go=\(Defs.go116) 
+"""
+}
+
+Steps: public_bump_discard: preguide.#Upload & {
+	Target: "\(Defs.public_dir)/\(Defs.public_go)"
+	Source: #"""
+package \#(Defs.public)
+
+import (
+    "fmt"
+    "io"
+)
+
+func \#(Defs.public_func) {
+    fmt.Fprintf(io.Discard, "This doesn't print anything")
+}
+"""#
+}
+
+Steps: public_bump_commit: preguide.#Command & {
+	Source: """
+cd \(Defs.public_dir)
+\(Defs.git.checkout) -b bump
+\(Defs.git.add) \(Defs.public_go) go.mod
+\(Defs.git.commit) -m 'Bump \(Defs.public) to go1.16'
+\(Defs.git.push) origin bump
+"""
+}
+
+Steps: go115default1: preguide.#Command & {
+	Source: """
+		alias go=\(Defs.go115) 
+		"""
+}
+
+Steps: gopher_update_fail: preguide.#Command & {
+	Source: """
+cd \(Defs.gopher_dir)
+# We launch this in a subshell to assert the status code
+code=$(\(Defs.cmdgo.get) -u -v \(Defs.public_mod)@bump; echo $?)
+
+# Assert that status code is correct or fail
+[ $code == 2 ] || false
+"""
+}
+
+Steps: public_rollback_mod: preguide.#Upload & {
+	Target: "\(Defs.public_dir)/\(Defs.public_go)"
+	Source: #"""
+// +build !go1.16
+
+package \#(Defs.public)
+
+import (
+    "fmt"
+    "io/ioutil"
+)
+
+func \#(Defs.public_func) {
+    fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+}
+"""#
+}
+
+Steps: public_add_buildtag: preguide.#Upload & {
+	Target: "\(Defs.public_dir)/\(Defs.public_go116)"
+	Source: #"""
+// +build go.1.16
+
+package \#(Defs.public)
+
+import (
+    "fmt"
+    "io"
+)
+
+func \#(Defs.public_func) {
+    fmt.Fprintf(io.Discard, "This doesn't print anything")
+}
+"""#
+}
+
+Steps: public_fix_commit: preguide.#Command & {
+	Source: """
+cd \(Defs.public_dir)
+\(Defs.git.checkout) -b bump_fix
+\(Defs.git.add) \(Defs.public_go) \(Defs.public_go116) go.mod
+\(Defs.git.commit) -m 'Fix \(Defs.public) bump to go1.16'
+\(Defs.git.push) origin bump_fix
+"""
+}
+
+Steps: gopher_update_ok: preguide.#Command & {
+	Source: """
+cd \(Defs.gopher_dir)
+\(Defs.cmdgo.get) -u -v \(Defs.public_mod)@bump_fix
+"""
+}

--- a/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
@@ -39,7 +39,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: "playwithgo/go1.15_1.16@sha256:6cea9fd5d2b1316120a40e7d8c2c9e0db0a408bcb80ffbaad36238cf066298ee"
+	Scenarios: go115: Image: "playwithgo/go1.15_1.16@sha256:38ee32afdd785e5f1d9e63033ce5d64cbd098207ed6506669105db97c2dbe9a1"
 }
 
 Steps: go115version: preguide.#Command & {

--- a/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15_1.16@sha256:6cea9fd5d2b1316120a40e7d8c2c9e0db0a408bcb80ffbaad36238cf066298ee"
+			Image: "playwithgo/go1.15_1.16@sha256:38ee32afdd785e5f1d9e63033ce5d64cbd098207ed6506669105db97c2dbe9a1"
 		}
 	}
 }]
@@ -530,14 +530,14 @@ Steps: {
 			CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
 			ExitCode: 0
 			Output: """
-				go: {{{.PUBLIC}}} latest => v0.0.0-20210516082250-842dcc186154
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516082250-842dcc186154
+				go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
 
 				"""
 			ComparisonOutput: """
 
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516082250-842dcc186154
-				go: {{{.PUBLIC}}} latest => v0.0.0-20210516082250-842dcc186154
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
+				go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
 				"""
 		}]
 	}
@@ -554,12 +554,12 @@ Steps: {
 			ExitCode: 2
 			Output: """
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
 
 				"""
 			ComparisonOutput: """
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
 
 				"""
 		}]
@@ -722,5 +722,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "98efc8027e023d99863fe8d8a94d454f723a36f64213b6be470376529f8d2128"
+Hash: "087597cb2f6d2340581cfe8324db65938ef581566661e67cf19e93cffaefbf16"
 Delims: ["{{{", "}}}"]

--- a/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
@@ -1,0 +1,685 @@
+package out
+
+Presteps: [{
+	Package: "github.com/play-with-go/gitea"
+	Path:    "/newuser"
+	Args: {
+		Repos: [{
+			Pattern: "public"
+			Private: false
+			Var:     "PUBLIC"
+		}]
+	}
+	Version: """
+		{
+		  "Path": "github.com/play-with-go/gitea/cmd/gitea",
+		  "Main": {
+		    "Path": "github.com/play-with-go/gitea",
+		    "Version": "v0.0.0-20210430163339-b27dc21b6036",
+		    "Sum": "h1:7wJ+VvtJk2GU9XtFGDeVwO6ohT8l5nu5h9A6YDCec+U=",
+		    "Replace": null
+		  },
+		  "Deps": [
+		    {
+		      "Path": "code.gitea.io/sdk/gitea",
+		      "Version": "v0.13.1",
+		      "Sum": "h1:Y7bpH2iO6Q0KhhMJfjP/LZ0AmiYITeRQlCD8b0oYqhk=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "cuelang.org/go",
+		      "Version": "v0.3.2",
+		      "Sum": "h1:/Am5yFDwqnaEi+g942OPM1M4/qtfVSm49wtkQbeh5Z4=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "github.com/cockroachdb/apd/v2",
+		      "Version": "v2.0.1",
+		      "Sum": "h1:y1Rh3tEU89D+7Tgbw+lp52T6p/GJLpDmNvr10UWqLTE=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "github.com/emicklei/proto",
+		      "Version": "v1.6.15",
+		      "Sum": "h1:XbpwxmuOPrdES97FrSfpyy67SSCV/wBIKXqgJzh6hNw=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "github.com/hashicorp/go-version",
+		      "Version": "v1.2.0",
+		      "Sum": "h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "github.com/mpvl/unique",
+		      "Version": "v0.0.0-20150818121801-cbe035fff7de",
+		      "Sum": "h1:D5x39vF5KCwKQaw+OC9ZPiLVHXz3UFw2+psEX+gYcto=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "github.com/pkg/errors",
+		      "Version": "v0.8.1",
+		      "Sum": "h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "github.com/play-with-go/preguide",
+		      "Version": "v0.0.2-0.20210430163307-e5ab271ba2e9",
+		      "Sum": "h1:dpSLI117TKb8MdLknsUYbQjKJpP6jzBYpfKKVszCZNI=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "golang.org/x/crypto",
+		      "Version": "v0.0.0-20200622213623-75b288015ac9",
+		      "Sum": "h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "golang.org/x/net",
+		      "Version": "v0.0.0-20201021035429-f5854403a974",
+		      "Sum": "h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "golang.org/x/text",
+		      "Version": "v0.3.3",
+		      "Sum": "h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "golang.org/x/xerrors",
+		      "Version": "v0.0.0-20200804184101-5ec99f83aff1",
+		      "Sum": "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "gopkg.in/retry.v1",
+		      "Version": "v1.0.3",
+		      "Sum": "h1:a9CArYczAVv6Qs6VGoLMio99GEs7kY9UzSF9+LD+iGs=",
+		      "Replace": null
+		    },
+		    {
+		      "Path": "gopkg.in/yaml.v3",
+		      "Version": "v3.0.0-20200121175148-a6ecf24a6d71",
+		      "Sum": "h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=",
+		      "Replace": null
+		    }
+		  ]
+		}
+		"""
+	Variables: ["GITEA_USERNAME", "GITEA_PRIV_KEY", "GITEA_PUB_KEY", "GITEA_KEYSCAN", "PUBLIC"]
+}]
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go115: {
+			Image: "lala"
+		}
+	}
+}]
+Scenarios: [{
+	Name:        "go115"
+	Description: "Go 1.15"
+}]
+Networks: ["playwithgo_pwg"]
+Env: []
+FilenameComment: false
+Steps: {
+	go115version: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go115version"
+		Order:           0
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go115 version"
+			ExitCode: 0
+			Output: """
+				go version go1.15.8 linux/amd64
+
+				"""
+			ComparisonOutput: """
+				go version go1.15.8 linux/amd64
+
+				"""
+		}]
+	}
+	go116version: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go116version"
+		Order:           1
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go116 version"
+			ExitCode: 0
+			Output: """
+				go version go1.16.3 linux/amd64
+
+				"""
+			ComparisonOutput: """
+				go version go1.16.3 linux/amd64
+
+				"""
+		}]
+	}
+	go115default: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go115default"
+		Order:           2
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "alias go=go115"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
+	public_init: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "public_init"
+		Order:           3
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "mkdir /home/gopher/public"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "cd /home/gopher/public"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "go mod init {{{.PUBLIC}}}"
+			ExitCode: 0
+			Output: """
+				go: creating new go.mod: module {{{.PUBLIC}}}
+
+				"""
+			ComparisonOutput: """
+				go: creating new go.mod: module {{{.PUBLIC}}}
+
+				"""
+		}, {
+			Negated:          false
+			CmdStr:           "git init -q"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "git remote add origin https://{{{.PUBLIC}}}.git"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
+	public_go_initial: {
+		StepType: 2
+		Name:     "public_go_initial"
+		Order:    4
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			package public
+
+			import (
+			    "fmt"
+			    "io/ioutil"
+			)
+
+			func DoSomething() {
+			    fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+			}
+			"""
+		Target: "/home/gopher/public/public.go"
+	}
+	public_initial_commit: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "public_initial_commit"
+		Order:           5
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "git add public.go go.mod"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "git commit -q -m 'Initial commit of public module'"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "git push -q origin main"
+			ExitCode: 0
+			Output: """
+				remote: . Processing 1 references        
+				remote: Processed 1 references in total        
+
+				"""
+			ComparisonOutput: """
+				remote: . Processing 1 references        
+				remote: Processed 1 references in total        
+
+				"""
+		}]
+	}
+	public_check_initial_porcelain: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: true
+		Name:            "public_check_initial_porcelain"
+		Order:           6
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "[ \"$(git status --porcelain)\" == \"\" ] || (git status && false)"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
+	gopher_init: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_init"
+		Order:           7
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "mkdir /home/gopher/gopher"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "cd /home/gopher/gopher"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "go mod init gopher"
+			ExitCode: 0
+			Output: """
+				go: creating new go.mod: module gopher
+
+				"""
+			ComparisonOutput: """
+				go: creating new go.mod: module gopher
+
+				"""
+		}]
+	}
+	gopher_go_initial: {
+		StepType: 2
+		Name:     "gopher_go_initial"
+		Order:    8
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			package main
+
+			import (
+
+			"{{{.PUBLIC}}}"
+			)
+
+			func main() {
+			    public.DoSomething()
+			}
+
+			"""
+		Target: "/home/gopher/gopher/gopher.go"
+	}
+	gopher_run: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_run"
+		Order:           9
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go run ."
+			ExitCode: 0
+			Output: """
+				go: finding module for package {{{.PUBLIC}}}
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+
+				"""
+			ComparisonOutput: """
+				go: finding module for package {{{.PUBLIC}}}
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+
+				"""
+		}]
+	}
+	go116default: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go116default"
+		Order:           10
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "alias go=go116"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
+	public_bump_discard: {
+		StepType: 2
+		Name:     "public_bump_discard"
+		Order:    11
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			package public
+
+			import (
+			    "fmt"
+			    "io"
+			)
+
+			func DoSomething() {
+			    fmt.Fprintf(io.Discard, "This doesn't print anything")
+			}
+			"""
+		Target: "/home/gopher/public/public.go"
+	}
+	public_bump_commit: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "public_bump_commit"
+		Order:           12
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "cd /home/gopher/public"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "git checkout -b bump"
+			ExitCode: 0
+			Output: """
+				Switched to a new branch 'bump'
+
+				"""
+			ComparisonOutput: """
+				Switched to a new branch 'bump'
+
+				"""
+		}, {
+			Negated:          false
+			CmdStr:           "git add public.go go.mod"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "git commit -q -m 'Bump public to go1.16'"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "git push -q origin bump"
+			ExitCode: 0
+			Output: """
+				remote: 
+				remote: Create a new pull request for 'bump':        
+				remote:   https://{{{.PUBLIC}}}/compare/main...bump        
+				remote: 
+				remote: . Processing 1 references
+				remote: Processed 1 references in total        
+
+				"""
+			ComparisonOutput: """
+				remote: 
+				remote: Create a new pull request for 'bump':        
+				remote:   https://{{{.PUBLIC}}}/compare/main...bump        
+				remote: 
+				remote: . Processing 1 references
+				remote: Processed 1 references in total        
+
+				"""
+		}]
+	}
+	go115default1: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go115default1"
+		Order:           13
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "alias go=go115"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
+	gopher_update_fail: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_update_fail"
+		Order:           14
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "cd /home/gopher/gopher"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "code=$(go get -u -v {{{.PUBLIC}}}@bump; echo $?)"
+			ExitCode: 0
+			Output: """
+				go: {{{.PUBLIC}}} bump => v0.0.0-20210510022530-3dbd6db9c7be
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022530-3dbd6db9c7be
+				{{{.PUBLIC}}}
+				# {{{.PUBLIC}}}
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+
+				"""
+			ComparisonOutput: """
+				go: {{{.PUBLIC}}} bump => v0.0.0-20210510022530-3dbd6db9c7be
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022530-3dbd6db9c7be
+				{{{.PUBLIC}}}
+				# {{{.PUBLIC}}}
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+
+				"""
+		}, {
+			Negated:          false
+			CmdStr:           "[ $code == 2 ] || false"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
+	public_rollback_mod: {
+		StepType: 2
+		Name:     "public_rollback_mod"
+		Order:    15
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			// +build !go1.16
+
+			package public
+
+			import (
+			    "fmt"
+			    "io/ioutil"
+			)
+
+			func DoSomething() {
+			    fmt.Fprintf(ioutil.Discard, "This doesn't print anything")
+			}
+			"""
+		Target: "/home/gopher/public/public.go"
+	}
+	public_add_buildtag: {
+		StepType: 2
+		Name:     "public_add_buildtag"
+		Order:    16
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			// +build go.1.16
+
+			package public
+
+			import (
+			    "fmt"
+			    "io"
+			)
+
+			func DoSomething() {
+			    fmt.Fprintf(io.Discard, "This doesn't print anything")
+			}
+			"""
+		Target: "/home/gopher/public/public_116.go"
+	}
+	public_fix_commit: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "public_fix_commit"
+		Order:           17
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "cd /home/gopher/public"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "git checkout -b bump_fix"
+			ExitCode: 0
+			Output: """
+				Switched to a new branch 'bump_fix'
+
+				"""
+			ComparisonOutput: """
+				Switched to a new branch 'bump_fix'
+
+				"""
+		}, {
+			Negated:          false
+			CmdStr:           "git add public.go public_116.go go.mod"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "git commit -q -m 'Fix public bump to go1.16'"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "git push -q origin bump_fix"
+			ExitCode: 0
+			Output: """
+				remote: 
+				remote: Create a new pull request for 'bump_fix':        
+				remote:   https://{{{.PUBLIC}}}/compare/main...bump_fix        
+				remote: 
+				remote: . Processing 1 references        
+				remote: Processed 1 references in total        
+
+				"""
+			ComparisonOutput: """
+				remote: 
+				remote: Create a new pull request for 'bump_fix':        
+				remote:   https://{{{.PUBLIC}}}/compare/main...bump_fix        
+				remote: 
+				remote: . Processing 1 references        
+				remote: Processed 1 references in total        
+
+				"""
+		}]
+	}
+	gopher_update_ok: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_update_ok"
+		Order:           18
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "cd /home/gopher/gopher"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "go get -u -v {{{.PUBLIC}}}@bump_fix"
+			ExitCode: 0
+			Output: """
+				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210510022545-65e54e92a856
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022545-65e54e92a856
+				{{{.PUBLIC}}}
+
+				"""
+			ComparisonOutput: """
+
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022545-65e54e92a856
+				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210510022545-65e54e92a856
+				{{{.PUBLIC}}}
+				"""
+		}]
+	}
+}
+Hash: "a65f6315f10a0cd883e90f8c1ead7bcc18b6a10a92b5d05e6009b80d7a12e981"
+Delims: ["{{{", "}}}"]

--- a/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
@@ -371,14 +371,14 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: finding module for package {{{.PUBLIC}}}
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
-				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
+				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
 
 				"""
 			ComparisonOutput: """
 				go: finding module for package {{{.PUBLIC}}}
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
-				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210510022515-3b5a503cc6e3
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
+				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
 
 				"""
 		}]
@@ -515,19 +515,19 @@ Steps: {
 			CmdStr:   "code=$(go get -u -v {{{.PUBLIC}}}@bump; echo $?)"
 			ExitCode: 0
 			Output: """
-				go: {{{.PUBLIC}}} bump => v0.0.0-20210510022530-3dbd6db9c7be
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022530-3dbd6db9c7be
+				go: {{{.PUBLIC}}} bump => v0.0.0-20210516021314-e2f48657c61e
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021314-e2f48657c61e
 				{{{.PUBLIC}}}
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
 
 				"""
 			ComparisonOutput: """
-				go: {{{.PUBLIC}}} bump => v0.0.0-20210510022530-3dbd6db9c7be
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022530-3dbd6db9c7be
+				go: {{{.PUBLIC}}} bump => v0.0.0-20210516021314-e2f48657c61e
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021314-e2f48657c61e
 				{{{.PUBLIC}}}
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210510022530-3dbd6db9c7be/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
 
 				"""
 		}, {
@@ -664,22 +664,20 @@ Steps: {
 			ComparisonOutput: ""
 		}, {
 			Negated:  false
-			CmdStr:   "go get -u -v {{{.PUBLIC}}}@bump_fix"
+			CmdStr:   "go get -d -v {{{.PUBLIC}}}@bump_fix"
 			ExitCode: 0
 			Output: """
-				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210510022545-65e54e92a856
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022545-65e54e92a856
-				{{{.PUBLIC}}}
+				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210516021327-c273d5742f90
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021327-c273d5742f90
 
 				"""
 			ComparisonOutput: """
 
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210510022545-65e54e92a856
-				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210510022545-65e54e92a856
-				{{{.PUBLIC}}}
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021327-c273d5742f90
+				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210516021327-c273d5742f90
 				"""
 		}]
 	}
 }
-Hash: "a65f6315f10a0cd883e90f8c1ead7bcc18b6a10a92b5d05e6009b80d7a12e981"
+Hash: "56560623b8d127d7ac5022951e9b12235f9456b2d590fa70e9cb1321eada231d"
 Delims: ["{{{", "}}}"]

--- a/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
@@ -114,7 +114,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "lala"
+			Image: "playwithgo/go1.15_1.16@sha256:6cea9fd5d2b1316120a40e7d8c2c9e0db0a408bcb80ffbaad36238cf066298ee"
 		}
 	}
 }]
@@ -358,29 +358,64 @@ Steps: {
 			"""
 		Target: "/home/gopher/gopher/gopher.go"
 	}
+	gopher_get: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_get"
+		Order:           9
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go get -d {{{.PUBLIC}}}@latest"
+			ExitCode: 0
+			Output: """
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+
+				"""
+			ComparisonOutput: """
+
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+				"""
+		}]
+	}
+	golist_gopher_1: {
+		StepType:        1
+		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+		DoNotTrim:       false
+		InformationOnly: true
+		Name:            "golist_gopher_1"
+		Order:           10
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+			ExitCode: 0
+			Output: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			ComparisonOutput: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+		}]
+	}
 	gopher_run: {
 		StepType:        1
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "gopher_run"
-		Order:           9
+		Order:           11
 		Terminal:        "term1"
 		Stmts: [{
-			Negated:  false
-			CmdStr:   "go run ."
-			ExitCode: 0
-			Output: """
-				go: finding module for package {{{.PUBLIC}}}
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
-				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
-
-				"""
-			ComparisonOutput: """
-				go: finding module for package {{{.PUBLIC}}}
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
-				go: found {{{.PUBLIC}}} in {{{.PUBLIC}}} v0.0.0-20210516021259-5911e81d2353
-
-				"""
+			Negated:          false
+			CmdStr:           "go run ."
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
 		}]
 	}
 	go116default: {
@@ -388,7 +423,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "go116default"
-		Order:           10
+		Order:           12
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -401,7 +436,7 @@ Steps: {
 	public_bump_discard: {
 		StepType: 2
 		Name:     "public_bump_discard"
-		Order:    11
+		Order:    13
 		Terminal: "term1"
 		Language: "go"
 		Renderer: {
@@ -426,7 +461,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "public_bump_commit"
-		Order:           12
+		Order:           14
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -434,18 +469,6 @@ Steps: {
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
-		}, {
-			Negated:  false
-			CmdStr:   "git checkout -b bump"
-			ExitCode: 0
-			Output: """
-				Switched to a new branch 'bump'
-
-				"""
-			ComparisonOutput: """
-				Switched to a new branch 'bump'
-
-				"""
 		}, {
 			Negated:          false
 			CmdStr:           "git add public.go go.mod"
@@ -460,23 +483,15 @@ Steps: {
 			ComparisonOutput: ""
 		}, {
 			Negated:  false
-			CmdStr:   "git push -q origin bump"
+			CmdStr:   "git push -q origin main"
 			ExitCode: 0
 			Output: """
-				remote: 
-				remote: Create a new pull request for 'bump':        
-				remote:   https://{{{.PUBLIC}}}/compare/main...bump        
-				remote: 
-				remote: . Processing 1 references
+				remote: . Processing 1 references        
 				remote: Processed 1 references in total        
 
 				"""
 			ComparisonOutput: """
-				remote: 
-				remote: Create a new pull request for 'bump':        
-				remote:   https://{{{.PUBLIC}}}/compare/main...bump        
-				remote: 
-				remote: . Processing 1 references
+				remote: . Processing 1 references        
 				remote: Processed 1 references in total        
 
 				"""
@@ -487,7 +502,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "go115default1"
-		Order:           13
+		Order:           15
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -497,12 +512,12 @@ Steps: {
 			ComparisonOutput: ""
 		}]
 	}
-	gopher_update_fail: {
+	gopher_update: {
 		StepType:        1
 		DoNotTrim:       false
 		InformationOnly: false
-		Name:            "gopher_update_fail"
-		Order:           14
+		Name:            "gopher_update"
+		Order:           16
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -512,36 +527,47 @@ Steps: {
 			ComparisonOutput: ""
 		}, {
 			Negated:  false
-			CmdStr:   "code=$(go get -u -v {{{.PUBLIC}}}@bump; echo $?)"
+			CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
 			ExitCode: 0
 			Output: """
-				go: {{{.PUBLIC}}} bump => v0.0.0-20210516021314-e2f48657c61e
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021314-e2f48657c61e
-				{{{.PUBLIC}}}
-				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
+				go: {{{.PUBLIC}}} latest => v0.0.0-20210516082250-842dcc186154
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516082250-842dcc186154
 
 				"""
 			ComparisonOutput: """
-				go: {{{.PUBLIC}}} bump => v0.0.0-20210516021314-e2f48657c61e
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021314-e2f48657c61e
-				{{{.PUBLIC}}}
+
+				go: downloading {{{.PUBLIC}}} v0.0.0-20210516082250-842dcc186154
+				go: {{{.PUBLIC}}} latest => v0.0.0-20210516082250-842dcc186154
+				"""
+		}]
+	}
+	gopher_run_fail: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_run_fail"
+		Order:           17
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  true
+			CmdStr:   "go run ."
+			ExitCode: 2
+			Output: """
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516021314-e2f48657c61e/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
 
 				"""
-		}, {
-			Negated:          false
-			CmdStr:           "[ $code == 2 ] || false"
-			ExitCode:         0
-			Output:           ""
-			ComparisonOutput: ""
+			ComparisonOutput: """
+				# {{{.PUBLIC}}}
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210516082250-842dcc186154/public.go:9:17: undefined: io.Discard
+
+				"""
 		}]
 	}
 	public_rollback_mod: {
 		StepType: 2
 		Name:     "public_rollback_mod"
-		Order:    15
+		Order:    18
 		Terminal: "term1"
 		Language: "go"
 		Renderer: {
@@ -566,7 +592,7 @@ Steps: {
 	public_add_buildtag: {
 		StepType: 2
 		Name:     "public_add_buildtag"
-		Order:    16
+		Order:    19
 		Terminal: "term1"
 		Language: "go"
 		Renderer: {
@@ -593,7 +619,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "public_fix_commit"
-		Order:           17
+		Order:           20
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -601,18 +627,6 @@ Steps: {
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
-		}, {
-			Negated:  false
-			CmdStr:   "git checkout -b bump_fix"
-			ExitCode: 0
-			Output: """
-				Switched to a new branch 'bump_fix'
-
-				"""
-			ComparisonOutput: """
-				Switched to a new branch 'bump_fix'
-
-				"""
 		}, {
 			Negated:          false
 			CmdStr:           "git add public.go public_116.go go.mod"
@@ -627,34 +641,26 @@ Steps: {
 			ComparisonOutput: ""
 		}, {
 			Negated:  false
-			CmdStr:   "git push -q origin bump_fix"
+			CmdStr:   "git push -q origin main"
 			ExitCode: 0
 			Output: """
-				remote: 
-				remote: Create a new pull request for 'bump_fix':        
-				remote:   https://{{{.PUBLIC}}}/compare/main...bump_fix        
-				remote: 
 				remote: . Processing 1 references        
 				remote: Processed 1 references in total        
 
 				"""
 			ComparisonOutput: """
-				remote: 
-				remote: Create a new pull request for 'bump_fix':        
-				remote:   https://{{{.PUBLIC}}}/compare/main...bump_fix        
-				remote: 
 				remote: . Processing 1 references        
 				remote: Processed 1 references in total        
 
 				"""
 		}]
 	}
-	gopher_update_ok: {
+	gopher_update_fix: {
 		StepType:        1
 		DoNotTrim:       false
 		InformationOnly: false
-		Name:            "gopher_update_ok"
-		Order:           18
+		Name:            "gopher_update_fix"
+		Order:           21
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -664,20 +670,57 @@ Steps: {
 			ComparisonOutput: ""
 		}, {
 			Negated:  false
-			CmdStr:   "go get -d -v {{{.PUBLIC}}}@bump_fix"
+			CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
 			ExitCode: 0
 			Output: """
-				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210516021327-c273d5742f90
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021327-c273d5742f90
+				go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210516021327-c273d5742f90
-				go: {{{.PUBLIC}}} bump_fix => v0.0.0-20210516021327-c273d5742f90
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
 				"""
 		}]
 	}
+	golist_gopher_2: {
+		StepType:        1
+		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+		DoNotTrim:       false
+		InformationOnly: true
+		Name:            "golist_gopher_2"
+		Order:           22
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+			ExitCode: 0
+			Output: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			ComparisonOutput: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+		}]
+	}
+	gopher_run_fix: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopher_run_fix"
+		Order:           23
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "go run ."
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}]
+	}
 }
-Hash: "56560623b8d127d7ac5022951e9b12235f9456b2d590fa70e9cb1321eada231d"
+Hash: "98efc8027e023d99863fe8d8a94d454f723a36f64213b6be470376529f8d2128"
 Delims: ["{{{", "}}}"]

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -287,6 +287,35 @@ package guides
 	Networks: ["playwithgo_pwg"]
 	Env: []
 }
+"2021-05-02-build-flags-backwards-compatibility": {
+	Delims: ["{{{", "}}}"]
+	Presteps: [{
+		Package: "github.com/play-with-go/gitea"
+		Path:    "/newuser"
+		Args: {
+			Repos: [{
+				Pattern: "public"
+				Private: false
+				Var:     "PUBLIC"
+			}]
+		}
+	}]
+	Terminals: [{
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go115: {
+				Image: "playwithgo/go1.15_1.16@sha256:6cea9fd5d2b1316120a40e7d8c2c9e0db0a408bcb80ffbaad36238cf066298ee"
+			}
+		}
+	}]
+	Scenarios: [{
+		Name:        "go115"
+		Description: "Go 1.15"
+	}]
+	Networks: ["playwithgo_pwg"]
+	Env: []
+}
 "2021-05-06-gosheffield-demo": {
 	Delims: ["{{{", "}}}"]
 	Terminals: [{

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -305,7 +305,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15_1.16@sha256:6cea9fd5d2b1316120a40e7d8c2c9e0db0a408bcb80ffbaad36238cf066298ee"
+				Image: "playwithgo/go1.15_1.16@sha256:38ee32afdd785e5f1d9e63033ce5d64cbd098207ed6506669105db97c2dbe9a1"
 			}
 		}
 	}]

--- a/guides/guides.go
+++ b/guides/guides.go
@@ -6,4 +6,4 @@
 
 package guide
 
-//go:generate go run github.com/play-with-go/preguide/cmd/preguide gen -run backwards -out ../_posts
+//go:generate go run github.com/play-with-go/preguide/cmd/preguide gen -out ../_posts

--- a/guides/guides.go
+++ b/guides/guides.go
@@ -6,4 +6,4 @@
 
 package guide
 
-//go:generate go run github.com/play-with-go/preguide/cmd/preguide gen -out ../_posts
+//go:generate go run github.com/play-with-go/preguide/cmd/preguide gen -run backwards -out ../_posts


### PR DESCRIPTION
This guide also depend on https://github.com/play-with-go/preguide/issues/194 and https://github.com/play-with-go/preguide/issues/193 outcomes. 

Pretty much all the guide is there, what's missing is just the conclusion and of course some good semantic and orthographic review. cc @myitcv  :)

