### PR TITLE
guides: fix build flags unstable output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,8 @@ jobs:
       run: _scripts/generateEverythingElse.sh
     - name: Tidy
       run: go mod tidy
+    - name: Verify commit is clean
+      run: test -z "$(git status --porcelain)" || (git status; git diff; false)
     - name: Run unity tests
       run: go run github.com/cue-sh/unity/cmd/unity test
     - name: Verify commit is clean

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -54,6 +54,8 @@ jobs:
       run: _scripts/generateEverythingElse.sh
     - name: Tidy
       run: go mod tidy
+    - name: Verify commit is clean
+      run: test -z "$(git status --porcelain)" || (git status; git diff; false)
     - name: Run unity tests
       run: go run github.com/cue-sh/unity/cmd/unity test
     - name: Verify commit is clean

--- a/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
+++ b/_posts/2021-05-02-build-flags-backwards-compatibility_go115_en.markdown
@@ -170,13 +170,13 @@ run again:
 
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpHT1BST1hZPWRpcmVjdCBnbyBnZXQgLWQge3t7LlBVQkxJQ319fUBsYXRlc3QK"><code class="language-.term1">$ cd /home/gopher/gopher
 $ GOPROXY=direct go get -d &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@latest
-go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20210517052223-fcd4ca0bf3d0
-go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20210517052223-fcd4ca0bf3d0
+go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; latest =&gt; v0.0.0-20060102150405-abcedf12345
+go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
 </code></pre>
 
 <pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .
 # &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
-../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+../go/pkg/mod/&#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345/public.go:9:17: undefined: io.Discard
 </code></pre>
 
 As you can see, when trying to run our `gopher` project using the

--- a/cue.mod/tests/eval.txt
+++ b/cue.mod/tests/eval.txt
@@ -13910,6 +13910,15 @@ Steps: {
         InformationOnly: false
         Terminal:        string
     }
+    golist_gopher_2: {
+        Name:            string
+        StepType:        1
+        Source:          "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+        RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+        DoNotTrim:       false
+        InformationOnly: true
+        Terminal:        string
+    }
     gopher_run_fail: {
         DoNotTrim:       false
         Name:            string
@@ -13990,7 +13999,7 @@ Steps: {
         InformationOnly: false
         Terminal:        string
     }
-    golist_gopher_2: {
+    golist_gopher_3: {
         Name:            string
         StepType:        1
         Source:          "go list -m -f {{.Version}} {{{.PUBLIC}}}"
@@ -14539,14 +14548,36 @@ Steps: {
             CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
             ExitCode: 0
             Output: """
-                go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
-                go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
+                go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+                go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
-                go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
-                go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
+                go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+                go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+                """
+        }]
+    }
+    golist_gopher_2: {
+        StepType:        1
+        RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+        DoNotTrim:       false
+        InformationOnly: true
+        Name:            "golist_gopher_2"
+        Order:           17
+        Terminal:        "term1"
+        Stmts: [{
+            Negated:  false
+            CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+            ExitCode: 0
+            Output: """
+                v0.0.0-20060102150405-abcedf12345
+
+                """
+            ComparisonOutput: """
+                v0.0.0-20060102150405-abcedf12345
+
                 """
         }]
     }
@@ -14555,7 +14586,7 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "gopher_run_fail"
-        Order:           17
+        Order:           18
         Terminal:        "term1"
         Stmts: [{
             Negated:  true
@@ -14563,12 +14594,12 @@ Steps: {
             ExitCode: 2
             Output: """
                 # {{{.PUBLIC}}}
-                ../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+                ../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20060102150405-abcedf12345/public.go:9:17: undefined: io.Discard
 
                 """
             ComparisonOutput: """
                 # {{{.PUBLIC}}}
-                ../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+                ../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20060102150405-abcedf12345/public.go:9:17: undefined: io.Discard
 
                 """
         }]
@@ -14576,7 +14607,7 @@ Steps: {
     public_rollback_mod: {
         StepType: 2
         Name:     "public_rollback_mod"
-        Order:    18
+        Order:    19
         Terminal: "term1"
         Language: "go"
         Renderer: {
@@ -14601,7 +14632,7 @@ Steps: {
     public_add_buildtag: {
         StepType: 2
         Name:     "public_add_buildtag"
-        Order:    19
+        Order:    20
         Terminal: "term1"
         Language: "go"
         Renderer: {
@@ -14628,7 +14659,7 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "public_fix_commit"
-        Order:           20
+        Order:           21
         Terminal:        "term1"
         Stmts: [{
             Negated:          false
@@ -14669,7 +14700,7 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "gopher_update_fix"
-        Order:           21
+        Order:           22
         Terminal:        "term1"
         Stmts: [{
             Negated:          false
@@ -14693,13 +14724,13 @@ Steps: {
                 """
         }]
     }
-    golist_gopher_2: {
+    golist_gopher_3: {
         StepType:        1
         RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
         DoNotTrim:       false
         InformationOnly: true
-        Name:            "golist_gopher_2"
-        Order:           22
+        Name:            "golist_gopher_3"
+        Order:           23
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
@@ -14720,7 +14751,7 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "gopher_run_fix"
-        Order:           23
+        Order:           24
         Terminal:        "term1"
         Stmts: [{
             Negated:          false
@@ -14731,7 +14762,7 @@ Steps: {
         }]
     }
 }
-Hash: "087597cb2f6d2340581cfe8324db65938ef581566661e67cf19e93cffaefbf16"
+Hash: "d394d1b632ff7b9ffeb462121bada6ac4ab1a4db97ee371d5d66f0b87ce5ee15"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -14938,6 +14969,9 @@ import "strings"
                     name: "Tidy"
                     run:  "go mod tidy"
                 }, {
+                    name: "Verify commit is clean"
+                    run:  "test -z \"$(git status --porcelain)\" || (git status; git diff; false)"
+                }, {
                     name: "Run unity tests"
                     run:  "go run github.com/cue-sh/unity/cmd/unity test"
                 }, {
@@ -15042,6 +15076,9 @@ import "strings"
                 }, {
                     name: "Tidy"
                     run:  "go mod tidy"
+                }, {
+                    name: "Verify commit is clean"
+                    run:  "test -z \"$(git status --porcelain)\" || (git status; git diff; false)"
                 }, {
                     name: "Run unity tests"
                     run:  "go run github.com/cue-sh/unity/cmd/unity test"
@@ -15188,6 +15225,9 @@ import "strings"
                 name: "Tidy"
                 run:  "go mod tidy"
             }, {
+                name: "Verify commit is clean"
+                run:  "test -z \"$(git status --porcelain)\" || (git status; git diff; false)"
+            }, {
                 name: "Run unity tests"
                 run:  "go run github.com/cue-sh/unity/cmd/unity test"
             }, {
@@ -15295,6 +15335,9 @@ test: {
                 name: "Tidy"
                 run:  "go mod tidy"
             }, {
+                name: "Verify commit is clean"
+                run:  "test -z \"$(git status --porcelain)\" || (git status; git diff; false)"
+            }, {
                 name: "Run unity tests"
                 run:  "go run github.com/cue-sh/unity/cmd/unity test"
             }, {
@@ -15397,6 +15440,9 @@ testmac: {
             }, {
                 name: "Tidy"
                 run:  "go mod tidy"
+            }, {
+                name: "Verify commit is clean"
+                run:  "test -z \"$(git status --porcelain)\" || (git status; git diff; false)"
             }, {
                 name: "Run unity tests"
                 run:  "go run github.com/cue-sh/unity/cmd/unity test"

--- a/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/go115_en_log.txt
@@ -72,11 +72,13 @@ remote: Processed 1 references in total
 $ alias go=go115
 $ cd /home/gopher/gopher
 $ GOPROXY=direct go get -d {{{.PUBLIC}}}@latest
-go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
-go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
+go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+$ go list -m -f {{.Version}} {{{.PUBLIC}}}
+v0.0.0-20060102150405-abcedf12345
 $ go run .
 # {{{.PUBLIC}}}
-../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20060102150405-abcedf12345/public.go:9:17: undefined: io.Discard
 $ cat <<EOD > /home/gopher/public/public.go
 // +build !go1.16
 

--- a/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/guide.cue
@@ -190,6 +190,14 @@ GOPROXY=direct \(Defs.cmdgo.get) -d \(Defs.public_mod)@latest
 """
 }
 
+Steps: golist_gopher_2: preguide.#Command & {
+	InformationOnly: true
+	RandomReplace:   "v0.0.0-\(_#StablePsuedoversionSuffix)"
+	Source:          """
+   go list -m -f {{.Version}} \(Defs.public_mod)
+   """
+}
+
 Steps: gopher_run_fail: preguide.#Command & {
 	Source: """
 ! \(Defs.cmdgo.run) .
@@ -248,7 +256,7 @@ GOPROXY=direct \(Defs.cmdgo.get) -d \(Defs.public_mod)@latest
 """
 }
 
-Steps: golist_gopher_2: preguide.#Command & {
+Steps: golist_gopher_3: preguide.#Command & {
 	InformationOnly: true
 	RandomReplace:   "v0.0.0-\(_#StablePsuedoversionSuffix)"
 	Source:          """

--- a/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
+++ b/guides/2021-05-02-build-flags-backwards-compatibility/out/gen_out.cue
@@ -530,14 +530,36 @@ Steps: {
 			CmdStr:   "GOPROXY=direct go get -d {{{.PUBLIC}}}@latest"
 			ExitCode: 0
 			Output: """
-				go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
+				go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
-				go: downloading {{{.PUBLIC}}} v0.0.0-20210517052223-fcd4ca0bf3d0
-				go: {{{.PUBLIC}}} latest => v0.0.0-20210517052223-fcd4ca0bf3d0
+				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PUBLIC}}} latest => v0.0.0-20060102150405-abcedf12345
+				"""
+		}]
+	}
+	golist_gopher_2: {
+		StepType:        1
+		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
+		DoNotTrim:       false
+		InformationOnly: true
+		Name:            "golist_gopher_2"
+		Order:           17
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go list -m -f {{.Version}} {{{.PUBLIC}}}"
+			ExitCode: 0
+			Output: """
+				v0.0.0-20060102150405-abcedf12345
+
+				"""
+			ComparisonOutput: """
+				v0.0.0-20060102150405-abcedf12345
+
 				"""
 		}]
 	}
@@ -546,7 +568,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "gopher_run_fail"
-		Order:           17
+		Order:           18
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  true
@@ -554,12 +576,12 @@ Steps: {
 			ExitCode: 2
 			Output: """
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20060102150405-abcedf12345/public.go:9:17: undefined: io.Discard
 
 				"""
 			ComparisonOutput: """
 				# {{{.PUBLIC}}}
-				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20210517052223-fcd4ca0bf3d0/public.go:9:17: undefined: io.Discard
+				../go/pkg/mod/{{{.PUBLIC}}}@v0.0.0-20060102150405-abcedf12345/public.go:9:17: undefined: io.Discard
 
 				"""
 		}]
@@ -567,7 +589,7 @@ Steps: {
 	public_rollback_mod: {
 		StepType: 2
 		Name:     "public_rollback_mod"
-		Order:    18
+		Order:    19
 		Terminal: "term1"
 		Language: "go"
 		Renderer: {
@@ -592,7 +614,7 @@ Steps: {
 	public_add_buildtag: {
 		StepType: 2
 		Name:     "public_add_buildtag"
-		Order:    19
+		Order:    20
 		Terminal: "term1"
 		Language: "go"
 		Renderer: {
@@ -619,7 +641,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "public_fix_commit"
-		Order:           20
+		Order:           21
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -660,7 +682,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "gopher_update_fix"
-		Order:           21
+		Order:           22
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -684,13 +706,13 @@ Steps: {
 				"""
 		}]
 	}
-	golist_gopher_2: {
+	golist_gopher_3: {
 		StepType:        1
 		RandomReplace:   "v0.0.0-20060102150405-abcedf12345"
 		DoNotTrim:       false
 		InformationOnly: true
-		Name:            "golist_gopher_2"
-		Order:           22
+		Name:            "golist_gopher_3"
+		Order:           23
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
@@ -711,7 +733,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "gopher_run_fix"
-		Order:           23
+		Order:           24
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
@@ -722,5 +744,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "087597cb2f6d2340581cfe8324db65938ef581566661e67cf19e93cffaefbf16"
+Hash: "d394d1b632ff7b9ffeb462121bada6ac4ab1a4db97ee371d5d66f0b87ce5ee15"
 Delims: ["{{{", "}}}"]

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -88,6 +88,10 @@ _#latestGo:     "1.16.3"
 				run:  "go mod tidy"
 			},
 			{
+				name: "Verify commit is clean"
+				run:  "test -z \"$(git status --porcelain)\" || (git status; git diff; false)"
+			},
+			{
 				name: "Run unity tests"
 				run:  "go run github.com/cue-sh/unity/cmd/unity test"
 			},


### PR DESCRIPTION
Also, move the check for clean commit before the unity check. Otherwise,
any actual diff pre unity is lost with a simple "there were unstaged
changes"