### PR TITLE
install-go-programs/en.markdown: Update link to mkcert source code

### DIFF
--- a/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
+++ b/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
@@ -16,7 +16,7 @@ can include at the top of their `README.md` explaining how to install the tool.
 
 Go 1.16 introduces a new way to install Go programs directly with the `go` command. This guide
 introduces the new mode of `go install` using the example of
-[`filippo.io/mkcert`](https://mkcert.io/), and is suitable for both end users and tool authors.
+[`filippo.io/mkcert`](https://filippo.io/mkcert), and is suitable for both end users and tool authors.
 
 ### Prerequisites
 

--- a/guides/2020-11-09-installing-go-programs-directly/en.markdown
+++ b/guides/2020-11-09-installing-go-programs-directly/en.markdown
@@ -14,7 +14,7 @@ can include at the top of their `README.md` explaining how to install the tool.
 
 Go 1.16 introduces a new way to install Go programs directly with the `go` command. This guide
 introduces the new mode of `{{{ .cmdgo.install }}}` using the example of
-[`{{{ .mkcert_pkg }}}`](https://mkcert.io/), and is suitable for both end users and tool authors.
+[`{{{ .mkcert_pkg }}}`](https://{{{ .mkcert_pkg }}}), and is suitable for both end users and tool authors.
 
 ### Prerequisites
 


### PR DESCRIPTION
This change replaces the broken link `https://mkcert.io` with a direct
link to the project repository `https://github.com/FiloSottile/mkcert`.

```
~>  curl -I https://mkcert.io
curl: (6) Could not resolve host: mkcert.io
```
