### PR TITLE
guides: add guide on shuffling go tests 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ guides-categories:
   - "Start here"
   - "Next steps"
   - "New features in Go 1.16"
+  - "What's coming in Go 1.17"
 
 #footer
 built-by: The play-with-go.dev Authors

--- a/_posts/2021-06-30-shuffling-tests_go117_en.markdown
+++ b/_posts/2021-06-30-shuffling-tests_go117_en.markdown
@@ -1,0 +1,146 @@
+---
+category: What's coming in Go 1.17
+difficulty: Beginner
+excerpt: Learn how to shuffle execution order of tests and benchmarks
+guide: 2021-06-30-shuffling-tests
+lang: en
+layout: post
+title: Shuffling Go tests
+---
+
+*By [Paschalis Tsilias](https://twitter.con/tpaschalis_), Go developer*.
+
+*Note: this is a preview of a `go test` feature that is due to land in Go 1.17*
+
+
+### Intro
+Testing is a first-class citizen in the Go ecosystem. This means that the barrier to testing Go projects is lower, and that there is little cognitive overhead to reading and understanding test code in unfamiliar projects. 
+
+But once suites start growing, unwanted dependencies may appear between different test and benchmark functions. In some cases, the suite may be passing, but actually fail if the tests are run in a different order. 
+
+This guide will walk you through creating a new Go package and its test file, which appears to run correctly, but contains a subtle flaw.
+
+You will use the new `-shuffle` flag to uncover this defect, and enforce randomization of test ordering to avoid such issues reappearing in the future. So, let’s get into it!
+
+### The `gopher` package
+So let’s build a new package by creating a folder and initializing a Go module.
+
+<pre data-command-src="bWtkaXIgL2hvbWUvZ29waGVyL2dvcGhlcmt2CmNkIC9ob21lL2dvcGhlci9nb3BoZXJrdgpnbyBtb2QgaW5pdCBnb3BoZXJrdgo="><code class="language-.term1">$ mkdir /home/gopher/gopherkv
+$ cd /home/gopher/gopherkv
+$ go mod init gopherkv
+go: creating new go.mod: module gopherkv
+</code></pre>
+
+Our `gopherkv` package will provide the smallest in-memory Key-Value storage, powered by a single `map[string]string`. Every grand project idea has to start somewhere right?
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL2dvcGhlcmt2" data-upload-src="Z29waGVya3YuZ28=:cGFja2FnZSBnb3BoZXJrdgoKdHlwZSBLViBzdHJ1Y3QgewoJZGF0YSBtYXBbc3RyaW5nXXN0cmluZwp9CgpmdW5jIENyZWF0ZShzaXplIHVpbnQpICpLViB7CglyZXR1cm4gJktWewoJCWRhdGE6IG1ha2UobWFwW3N0cmluZ11zdHJpbmcsIHNpemUpLAoJfQp9CgpmdW5jIChrdiAqS1YpIEdldChrZXkgc3RyaW5nKSAoc3RyaW5nLCBib29sKSB7Cgl2LCBvayA6PSBrdi5kYXRhW2tleV0KCXJldHVybiB2LCBvawp9CgpmdW5jIChrdiAqS1YpIFNldChrZXksIHZhbHVlIHN0cmluZykgewoJa3YuZGF0YVtrZXldID0gdmFsdWUKfQoKZnVuYyAoa3YgKktWKSBQdXJnZSgpIHsKCWt2LmRhdGEgPSBtYWtlKG1hcFtzdHJpbmddc3RyaW5nKQp9" data-upload-term=".term1"><code class="language-go">package gopherkv
+
+type KV struct &#123;
+	data map[string]string
+&#125;
+
+func Create(size uint) *KV &#123;
+	return &amp;KV&#123;
+		data: make(map[string]string, size),
+	&#125;
+&#125;
+
+func (kv *KV) Get(key string) (string, bool) &#123;
+	v, ok := kv.data[key]
+	return v, ok
+&#125;
+
+func (kv *KV) Set(key, value string) &#123;
+	kv.data[key] = value
+&#125;
+
+func (kv *KV) Purge() &#123;
+	kv.data = make(map[string]string)
+&#125;</code></pre>
+
+
+### Let’s test it!
+So let’s create a new `gopher_test.go` file which will test the functionality present in the `gopher` package.
+
+<pre data-upload-path="L2hvbWUvZ29waGVyL2dvcGhlcmt2" data-upload-src="Z29waGVya3ZfdGVzdC5nbw==:cGFja2FnZSBnb3BoZXJrdgoKaW1wb3J0ICJ0ZXN0aW5nIgoKdmFyIGt2ICpLVgoKZnVuYyBUZXN0Q3JlYXRlS1YodCAqdGVzdGluZy5UKSB7CglrdiA9IENyZWF0ZSg1MTIpCglpZiBrdiA9PSBuaWwgewoJCXQuRXJyb3JmKCJleHBlY3RlZCBuZXdseSBjcmVhdGVkIGt2IHN0b3JlIHRvIG5vdCBiZSBuaWwiKQoJfQp9CgpmdW5jIFRlc3RTZXQodCAqdGVzdGluZy5UKSB7Cglrdi5TZXQoImZvbyIsICJiYXIiKQoKCWlmIGxlbihrdi5kYXRhKSAhPSAxIHsKCQl0LkVycm9yZigiZXhwZWN0ZWQgZXhhY3RseSBvbmUgdmFsdWUgdG8gYmUgc2V0IikKCX0KfQoKZnVuYyBUZXN0R2V0KHQgKnRlc3RpbmcuVCkgewoJdmFsLCBleGlzdHMgOj0ga3YuR2V0KCJmb28iKQoJaWYgdmFsICE9ICJiYXIiIHx8ICFleGlzdHMgewoJCXQuRXJyb3JmKCJleHBlY3RlZCBmb286YmFyIHBhaXIgdG8gaGF2ZSBiZWVuIGZldGNoZWQgY29ycmVjdGx5IikKCX0KfQoKZnVuYyBUZXN0UHVyZ2UodCAqdGVzdGluZy5UKSB7Cglrdi5QdXJnZSgpCglsZW5OZXcgOj0gbGVuKGt2LmRhdGEpCgoJaWYgbGVuTmV3ICE9IDAgewoJCXQuRXJyb3JmKCJleHBlY3RlZCBhIGxlbmd0aCBvZiAwIGFmdGVyIHB1cmdpbmciKQoJfQp9" data-upload-term=".term1"><code class="language-go">package gopherkv
+
+import &#34;testing&#34;
+
+var kv *KV
+
+func TestCreateKV(t *testing.T) &#123;
+	kv = Create(512)
+	if kv == nil &#123;
+		t.Errorf(&#34;expected newly created kv store to not be nil&#34;)
+	&#125;
+&#125;
+
+func TestSet(t *testing.T) &#123;
+	kv.Set(&#34;foo&#34;, &#34;bar&#34;)
+
+	if len(kv.data) != 1 &#123;
+		t.Errorf(&#34;expected exactly one value to be set&#34;)
+	&#125;
+&#125;
+
+func TestGet(t *testing.T) &#123;
+	val, exists := kv.Get(&#34;foo&#34;)
+	if val != &#34;bar&#34; || !exists &#123;
+		t.Errorf(&#34;expected foo:bar pair to have been fetched correctly&#34;)
+	&#125;
+&#125;
+
+func TestPurge(t *testing.T) &#123;
+	kv.Purge()
+	lenNew := len(kv.data)
+
+	if lenNew != 0 &#123;
+		t.Errorf(&#34;expected a length of 0 after purging&#34;)
+	&#125;
+&#125;</code></pre>
+
+Let's actually run the tests in this file
+
+<pre data-command-src="Z28gdGVzdCAtY292ZXIgLi8uLi4K"><code class="language-.term1">$ go test -cover ./...
+ok  	gopherkv	0.002s	coverage: 100.0% of statements
+</code></pre>
+
+It seems that we not only have a passing test suite, but *also* that we're achieving 100% coverage for our package. 
+
+Sounds like we're off to a pretty good start, right?
+
+### Let’s shuffle things up!
+Some of you may be already raising some concerns regarding the tests we wrote. They contain a subtle flaw that may not be immediately apparent. 
+
+Let’s run the test suite again and randomize the execution order by using `go test ./… -shuffle=<seed>`.
+
+<pre data-command-src="Z28gdGVzdCAtc2h1ZmZsZT01IC4vLi4uIHx8IHRydWUK"><code class="language-.term1">$ go test -shuffle=5 ./... || true
+-test.shuffle 5
+--- FAIL: TestGet (0.00s)
+    gopherkv_test.go:25: expected foo:bar pair to have been fetched correctly
+FAIL
+FAIL	gopherkv	0.002s
+FAIL
+</code></pre>
+
+We now get a failure, and our 'green' test suite may not be so great after all! 
+
+The way that the tests initialize and use the shared `kv` pacakge-level variable, makes them dependent on each other and a different execution order will result in failures.
+
+We can see, that since the test failed Go reports the seed used for the current run so that such failures can be reproduced anywhere by running `go test ./… -shuffle=N`.
+
+### Along the -count flag 
+The `-count` flag is often used with the go test command, either to disable caching or uncover flaky tests. 
+
+Whenever the `-shuffle` and `-count` flags are used together, the execution order will be randomized once at the start, and then re-used for the next runs. This can help to spot rare cases of flaky tests failing for specific test seeds.
+
+### Do I always need to provide a seed value?
+One way to strengthen your tests suite is to run them using the `-shuffle=on` flag. Each time, a new seed will be selected based on your system's clock.
+
+### Conclusion
+That’s all! This guide has introduced the `-shuffle` flag for the go test command, demonstrated how test reordering can uncover flaws in our test suite, and how we can continously try to detect and prevent such issues in the future. 
+
+As a next step you might like to consider:
+* [Developer tools as module dependencies](/tools-as-dependencies_go115_en/)
+* [How to use and tweak Staticcheck](/using-staticcheck_go115_en/)
+<script>let pageGuide="2021-06-30-shuffling-tests"; let pageLanguage="en"; let pageScenario="go117";</script>

--- a/guide.cue
+++ b/guide.cue
@@ -14,6 +14,7 @@ _#installGo:          "playwithgo/installgo1.15.8@sha256:0e480b658f50b85b8eb40c4
 _#go115LatestVersion: "go1.15.8"
 _#go115LatestImage:   "playwithgo/go1.15.8@sha256:7640da09d1555c4dddbba7f1b96051af2816e6542005176b749f38865ee0454c"
 _#go116LatestImage:   "playwithgo/go1.16@sha256:3ae1950433998a2be8c8ce3b1cb6479e6541f1e32443447a24085cfe09e2c391"
+_#go117LatestImage:   "tpaschalis-gotip"
 
 _#golangToolsLatest: "v0.0.0-20201105220310-78b158585360"
 

--- a/guides/2021-06-30-shuffling-tests/en.markdown
+++ b/guides/2021-06-30-shuffling-tests/en.markdown
@@ -1,0 +1,72 @@
+---
+layout: post
+title:  "Shuffling Go tests"
+excerpt: "Learn how to shuffle execution order of tests and benchmarks"
+category: What's coming in Go 1.17
+difficulty: Beginner
+---
+
+*By [Paschalis Tsilias](https://twitter.con/tpaschalis_), Go developer*.
+
+*Note: this is a preview of a `go test` feature that is due to land in Go 1.17*
+
+
+### Intro
+Testing is a first-class citizen in the Go ecosystem. This means that the barrier to testing Go projects is lower, and that there is little cognitive overhead to reading and understanding test code in unfamiliar projects. 
+
+But once suites start growing, unwanted dependencies may appear between different test and benchmark functions. In some cases, the suite may be passing, but actually fail if the tests are run in a different order. 
+
+This guide will walk you through creating a new Go package and its test file, which appears to run correctly, but contains a subtle flaw.
+
+You will use the new `-shuffle` flag to uncover this defect, and enforce randomization of test ordering to avoid such issues reappearing in the future. So, let’s get into it!
+
+### The `gopher` package
+So let’s build a new package by creating a folder and initializing a Go module.
+
+{{{ step "gopherkv_create" }}}
+
+Our `gopherkv` package will provide the smallest in-memory Key-Value storage, powered by a single `map[string]string`. Every grand project idea has to start somewhere right?
+
+{{{ step "gopherkv_initial" }}}
+
+
+### Let’s test it!
+So let’s create a new `gopher_test.go` file which will test the functionality present in the `gopher` package.
+
+{{{ step "gopherkv_initial_test" }}}
+
+Let's actually run the tests in this file
+
+{{{ step "go_test_initial" }}}
+
+It seems that we not only have a passing test suite, but *also* that we're achieving 100% coverage for our package. 
+
+Sounds like we're off to a pretty good start, right?
+
+### Let’s shuffle things up!
+Some of you may be already raising some concerns regarding the tests we wrote. They contain a subtle flaw that may not be immediately apparent. 
+
+Let’s run the test suite again and randomize the execution order by using `go test ./… -shuffle=<seed>`.
+
+{{{ step "go_test_shuffle_100" }}}
+
+We now get a failure, and our 'green' test suite may not be so great after all! 
+
+The way that the tests initialize and use the shared `kv` pacakge-level variable, makes them dependent on each other and a different execution order will result in failures.
+
+We can see, that since the test failed Go reports the seed used for the current run so that such failures can be reproduced anywhere by running `go test ./… -shuffle=N`.
+
+### Along the -count flag 
+The `-count` flag is often used with the go test command, either to disable caching or uncover flaky tests. 
+
+Whenever the `-shuffle` and `-count` flags are used together, the execution order will be randomized once at the start, and then re-used for the next runs. This can help to spot rare cases of flaky tests failing for specific test seeds.
+
+### Do I always need to provide a seed value?
+One way to strengthen your tests suite is to run them using the `-shuffle=on` flag. Each time, a new seed will be selected based on your system's clock.
+
+### Conclusion
+That’s all! This guide has introduced the `-shuffle` flag for the go test command, demonstrated how test reordering can uncover flaws in our test suite, and how we can continously try to detect and prevent such issues in the future. 
+
+As a next step you might like to consider:
+* [Developer tools as module dependencies](/tools-as-dependencies_go115_en/)
+* [How to use and tweak Staticcheck](/using-staticcheck_go115_en/)

--- a/guides/2021-06-30-shuffling-tests/go117_en_log.txt
+++ b/guides/2021-06-30-shuffling-tests/go117_en_log.txt
@@ -1,0 +1,77 @@
+$ mkdir /home/gopher/gopherkv
+$ cd /home/gopher/gopherkv
+$ go mod init gopherkv
+go: creating new go.mod: module gopherkv
+$ cat <<EOD > /home/gopher/gopherkv/gopherkv.go
+package gopherkv
+
+type KV struct {
+	data map[string]string
+}
+
+func Create(size uint) *KV {
+	return &KV{
+		data: make(map[string]string, size),
+	}
+}
+
+func (kv *KV) Get(key string) (string, bool) {
+	v, ok := kv.data[key]
+	return v, ok
+}
+
+func (kv *KV) Set(key, value string) {
+	kv.data[key] = value
+}
+
+func (kv *KV) Purge() {
+	kv.data = make(map[string]string)
+}
+EOD
+$ cat <<EOD > /home/gopher/gopherkv/gopherkv_test.go
+package gopherkv
+
+import "testing"
+
+var kv *KV
+
+func TestCreateKV(t *testing.T) {
+	kv = Create(512)
+	if kv == nil {
+		t.Errorf("expected newly created kv store to not be nil")
+	}
+}
+
+func TestSet(t *testing.T) {
+	kv.Set("foo", "bar")
+
+	if len(kv.data) != 1 {
+		t.Errorf("expected exactly one value to be set")
+	}
+}
+
+func TestGet(t *testing.T) {
+	val, exists := kv.Get("foo")
+	if val != "bar" || !exists {
+		t.Errorf("expected foo:bar pair to have been fetched correctly")
+	}
+}
+
+func TestPurge(t *testing.T) {
+	kv.Purge()
+	lenNew := len(kv.data)
+
+	if lenNew != 0 {
+		t.Errorf("expected a length of 0 after purging")
+	}
+}
+EOD
+$ go test -cover ./...
+ok  	gopherkv	0.002s	coverage: 100.0% of statements
+$ go test -shuffle=5 ./... || true
+-test.shuffle 5
+--- FAIL: TestGet (0.00s)
+    gopherkv_test.go:25: expected foo:bar pair to have been fetched correctly
+FAIL
+FAIL	gopherkv	0.002s
+FAIL

--- a/guides/2021-06-30-shuffling-tests/guide.cue
+++ b/guides/2021-06-30-shuffling-tests/guide.cue
@@ -1,0 +1,125 @@
+package guide
+
+import (
+	"github.com/play-with-go/preguide"
+)
+
+Defs: {
+	_#commonDefs
+	staticcheck_version:      "v0.0.1-2020.1.6"
+	staticcheck_conf:         "staticcheck.conf"
+	staticcheck_st1000:       "ST1000"
+	staticcheck_sa4018:       "SA4018"
+	staticcheck_sa5009:       "SA5009"
+	staticcheck_explain_flag: "-explain"
+	gopherkv:                     "gopherkv"
+	gopherkv_dir:                 "/home/gopher/\(gopherkv)"
+	gopherkv_go:                  "\(gopherkv).go"
+	gopherkv_test_go:             "\(gopherkv)_test.go"
+	gopherkv_mod:                 "\(gopherkv)"
+}
+
+Scenarios: go117: preguide.#Scenario & {
+	Description: "Go 1.17"
+}
+
+Terminals: term1: preguide.#Terminal & {
+	Description: "The main terminal"
+	Scenarios: go117: Image: _#go117LatestImage
+}
+
+Steps: gopherkv_create: preguide.#Command & {
+	Source: """
+		mkdir \(Defs.gopherkv_dir)
+		cd \(Defs.gopherkv_dir)
+		go mod init \(Defs.gopherkv_mod)
+		"""
+}
+
+
+Steps: gopherkv_initial: preguide.#Upload & {
+	Target:   "\(Defs.gopherkv_dir)/\(Defs.gopherkv_go)"
+	//Renderer: preguide.#RenderDiff
+	Source:   #"""
+		package \#(Defs.gopherkv)
+
+		type KV struct {
+			data map[string]string
+		}
+
+		func Create(size uint) *KV {
+			return &KV{
+				data: make(map[string]string, size),
+			}
+		}
+
+		func (kv *KV) Get(key string) (string, bool) {
+			v, ok := kv.data[key]
+			return v, ok
+		}
+
+		func (kv *KV) Set(key, value string) {
+			kv.data[key] = value
+		}
+
+		func (kv *KV) Purge() {
+			kv.data = make(map[string]string)
+		}
+		"""#
+}
+
+Steps: gopherkv_initial_test: preguide.#Upload & {
+	Target:   "\(Defs.gopherkv_dir)/\(Defs.gopherkv_test_go)"
+	//Renderer: preguide.#RenderDiff
+	Source:   #"""
+		package \#(Defs.gopherkv)
+
+		import "testing"
+
+		var kv *KV
+
+		func TestCreateKV(t *testing.T) {
+			kv = Create(512)
+			if kv == nil {
+				t.Errorf("expected newly created kv store to not be nil")
+			}
+		}
+
+		func TestSet(t *testing.T) {
+			kv.Set("foo", "bar")
+
+			if len(kv.data) != 1 {
+				t.Errorf("expected exactly one value to be set")
+			}
+		}
+
+		func TestGet(t *testing.T) {
+			val, exists := kv.Get("foo")
+			if val != "bar" || !exists {
+				t.Errorf("expected foo:bar pair to have been fetched correctly")
+			}
+		}
+
+		func TestPurge(t *testing.T) {
+			kv.Purge()
+			lenNew := len(kv.data)
+
+			if lenNew != 0 {
+				t.Errorf("expected a length of 0 after purging")
+			}
+		}
+		"""#
+}
+
+Steps: go_test_initial: preguide.#Command & {
+	Source: """
+		go test -cover ./... 
+		"""
+}
+
+Steps: go_test_shuffle_100: preguide.#Command & {
+	Source: """
+		go test -shuffle=5  ./... || true
+		"""
+}
+

--- a/guides/2021-06-30-shuffling-tests/out/gen_out.cue
+++ b/guides/2021-06-30-shuffling-tests/out/gen_out.cue
@@ -1,0 +1,193 @@
+package out
+
+Terminals: [{
+	Name:        "term1"
+	Description: "The main terminal"
+	Scenarios: {
+		go117: {
+			Image: "tpaschalis-gotip"
+		}
+	}
+}]
+Scenarios: [{
+	Name:        "go117"
+	Description: "Go 1.17"
+}]
+Networks: ["playwithgo_pwg"]
+Env: []
+FilenameComment: false
+Steps: {
+	gopherkv_create: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "gopherkv_create"
+		Order:           0
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:          false
+			CmdStr:           "mkdir /home/gopher/gopherkv"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:          false
+			CmdStr:           "cd /home/gopher/gopherkv"
+			ExitCode:         0
+			Output:           ""
+			ComparisonOutput: ""
+		}, {
+			Negated:  false
+			CmdStr:   "go mod init gopherkv"
+			ExitCode: 0
+			Output: """
+				go: creating new go.mod: module gopherkv
+
+				"""
+			ComparisonOutput: """
+				go: creating new go.mod: module gopherkv
+
+				"""
+		}]
+	}
+	gopherkv_initial: {
+		StepType: 2
+		Name:     "gopherkv_initial"
+		Order:    1
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			package gopherkv
+
+			type KV struct {
+			\tdata map[string]string
+			}
+
+			func Create(size uint) *KV {
+			\treturn &KV{
+			\t\tdata: make(map[string]string, size),
+			\t}
+			}
+
+			func (kv *KV) Get(key string) (string, bool) {
+			\tv, ok := kv.data[key]
+			\treturn v, ok
+			}
+
+			func (kv *KV) Set(key, value string) {
+			\tkv.data[key] = value
+			}
+
+			func (kv *KV) Purge() {
+			\tkv.data = make(map[string]string)
+			}
+			"""
+		Target: "/home/gopher/gopherkv/gopherkv.go"
+	}
+	gopherkv_initial_test: {
+		StepType: 2
+		Name:     "gopherkv_initial_test"
+		Order:    2
+		Terminal: "term1"
+		Language: "go"
+		Renderer: {
+			RendererType: 1
+		}
+		Source: """
+			package gopherkv
+
+			import "testing"
+
+			var kv *KV
+
+			func TestCreateKV(t *testing.T) {
+			\tkv = Create(512)
+			\tif kv == nil {
+			\t\tt.Errorf("expected newly created kv store to not be nil")
+			\t}
+			}
+
+			func TestSet(t *testing.T) {
+			\tkv.Set("foo", "bar")
+
+			\tif len(kv.data) != 1 {
+			\t\tt.Errorf("expected exactly one value to be set")
+			\t}
+			}
+
+			func TestGet(t *testing.T) {
+			\tval, exists := kv.Get("foo")
+			\tif val != "bar" || !exists {
+			\t\tt.Errorf("expected foo:bar pair to have been fetched correctly")
+			\t}
+			}
+
+			func TestPurge(t *testing.T) {
+			\tkv.Purge()
+			\tlenNew := len(kv.data)
+
+			\tif lenNew != 0 {
+			\t\tt.Errorf("expected a length of 0 after purging")
+			\t}
+			}
+			"""
+		Target: "/home/gopher/gopherkv/gopherkv_test.go"
+	}
+	go_test_initial: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go_test_initial"
+		Order:           3
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go test -cover ./..."
+			ExitCode: 0
+			Output: """
+				ok  \tgopherkv\t0.002s\tcoverage: 100.0% of statements
+
+				"""
+			ComparisonOutput: """
+				ok  \tgopherkv\t0.002s\tcoverage: 100.0% of statements
+
+				"""
+		}]
+	}
+	go_test_shuffle_100: {
+		StepType:        1
+		DoNotTrim:       false
+		InformationOnly: false
+		Name:            "go_test_shuffle_100"
+		Order:           4
+		Terminal:        "term1"
+		Stmts: [{
+			Negated:  false
+			CmdStr:   "go test -shuffle=5 ./... || true"
+			ExitCode: 0
+			Output: """
+				-test.shuffle 5
+				--- FAIL: TestGet (0.00s)
+				    gopherkv_test.go:25: expected foo:bar pair to have been fetched correctly
+				FAIL
+				FAIL\tgopherkv\t0.002s
+				FAIL
+
+				"""
+			ComparisonOutput: """
+				-test.shuffle 5
+				--- FAIL: TestGet (0.00s)
+				    gopherkv_test.go:25: expected foo:bar pair to have been fetched correctly
+				FAIL
+				FAIL\tgopherkv\t0.002s
+				FAIL
+
+				"""
+		}]
+	}
+}
+Hash: "af76bb04ee3ea515fd442f2778bc531edbdb46550d1e4e353e73f00963055217"
+Delims: ["{{{", "}}}"]

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -334,4 +334,22 @@ package guides
 	Networks: ["playwithgo_pwg"]
 	Env: []
 }
+"2021-06-30-shuffling-tests": {
+	Delims: ["{{{", "}}}"]
+	Terminals: [{
+		Name:        "term1"
+		Description: "The main terminal"
+		Scenarios: {
+			go117: {
+				Image: "tpaschalis-gotip"
+			}
+		}
+	}]
+	Scenarios: [{
+		Name:        "go117"
+		Description: "Go 1.17"
+	}]
+	Networks: ["playwithgo_pwg"]
+	Env: []
+}
 


### PR DESCRIPTION
## TODOS

- [ ] Polish text and example code
- [ ] See if there's a way to include failing tests in the guide, without resorting to hacks like `go test -shuffle=5  ./... || true`. Currently a non-0 exit code leads to the guide not compiling
- [ ] Find a fix for [this](https://github.com/play-with-go/docker/pull/33) problem, and create a Go image that contains the new Go 1.17 feature
- [ ] Ask why I cannot `preguide.#Upload` locally on any guide.  
On the website I get an red error popup with ` Something went uploading file wrong. Please try again.`.   
On the console logs I get 
```
pwd           | [negroni] Started POST /sessions/c3et6qf8j02g00cn97n0/instances/c3et6qf8_c3et6rf8j02g00cn97ng/uploads
pwd           | [negroni] Completed 500 Internal Server Error in 11.69038ms
pwd           | 2021/07/01 14:38:42 Error while uploading file [gopherkv.go]. Error: Error response from daemon: getent unable to find entry "1000" in passwd database
```