### PR TITLE
ci: docker login to fix macOS auth issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,8 @@ jobs:
     - name: mac CI setup
       run: ./_scripts/macCISetup.sh
       if: ${{ matrix.os == 'macos-latest' }}
+    - name: Docker login
+      run: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN
     - name: Ensure docker setup
       run: ./_scripts/ensureDocker.sh
     - name: Env setup

--- a/.github/workflows/testmac.yml
+++ b/.github/workflows/testmac.yml
@@ -2,6 +2,14 @@
 
 name: TestMac
 on:
+  push:
+    branches:
+    - main
+    tags:
+    - v*
+  pull_request:
+    branches:
+    - '**'
   schedule:
   - cron: 0 9 * * *
 env:
@@ -34,6 +42,8 @@ jobs:
     - name: mac CI setup
       run: ./_scripts/macCISetup.sh
       if: ${{ matrix.os == 'macos-latest' }}
+    - name: Docker login
+      run: docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN
     - name: Ensure docker setup
       run: ./_scripts/ensureDocker.sh
     - name: Env setup

--- a/_posts/2020-11-08-retract-module-versions_go116_en.markdown
+++ b/_posts/2020-11-08-retract-module-versions_go116_en.markdown
@@ -47,7 +47,9 @@ You should already have completed:
 
 This guide is running using:
 
-<pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
+<pre data-command-src="ZWNobyBIZWxsbyB3b3JsZCEKZ28gdmVyc2lvbgo="><code class="language-.term1">$ echo Hello world!
+Hello world!
+$ go version
 go version go1.16 linux/amd64
 </code></pre>
 

--- a/_scripts/macCISetup.sh
+++ b/_scripts/macCISetup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # We can't have this line because the default version of bash on mac os too old
 # shopt -s inherit_errexit
 
-# With thanks/credit to https://github.com/docker/for-mac/issues/2359#issuecomment-607154849
+# With thanks/credit to https://github.com/docker/for-mac/issues/2359#issuecomment-853420567
 
 # Update brew to make sure we're using the latest formulae
 brew update
@@ -23,20 +23,53 @@ which find
 
 ###############################
 # Docker
-
-# Install Docker
 brew install --cask docker
-
-# Allow the app to run without confirmation
+# allow the app to run without confirmation
 xattr -d -r com.apple.quarantine /Applications/Docker.app
 
 # preemptively do docker.app's setup to avoid any gui prompts
 sudo /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools
-sudo /bin/cp /Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons/
+
+# the plist we need used to be in /Applications/Docker.app/Contents/Resources, but
+# is now dynamically generated. So we dynamically generate our own
+sudo tee "/Library/LaunchDaemons/com.docker.vmnetd.plist" > /dev/null <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+ <key>Label</key>
+ <string>com.docker.vmnetd</string>
+ <key>Program</key>
+ <string>/Library/PrivilegedHelperTools/com.docker.vmnetd</string>
+ <key>ProgramArguments</key>
+ <array>
+  <string>/Library/PrivilegedHelperTools/com.docker.vmnetd</string>
+ </array>
+ <key>RunAtLoad</key>
+ <true/>
+ <key>Sockets</key>
+ <dict>
+  <key>Listener</key>
+  <dict>
+   <key>SockPathMode</key>
+   <integer>438</integer>
+   <key>SockPathName</key>
+   <string>/var/run/com.docker.vmnetd.sock</string>
+  </dict>
+ </dict>
+ <key>Version</key>
+ <string>59</string>
+</dict>
+</plist>
+
+EOF
+
 sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
 sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
 sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
 
+# Random sleep for good measure
+sleep 15
 
 # Run
 [[ $(uname) == 'Darwin' ]] || { echo "This function only runs on macOS." >&2; exit 2; }

--- a/cue.mod/tests/eval.txt
+++ b/cue.mod/tests/eval.txt
@@ -7157,10 +7157,13 @@ Terminals: {
 }
 Steps: {
     goversion: {
-        DoNotTrim:       false
-        Name:            string
-        StepType:        1
-        Source:          "go version"
+        DoNotTrim: false
+        Name:      string
+        StepType:  1
+        Source: """
+            echo Hello world!
+            go version
+            """
         InformationOnly: false
         Terminal:        string
     }
@@ -7910,6 +7913,18 @@ Steps: {
         Order:           0
         Terminal:        "term1"
         Stmts: [{
+            Negated:  false
+            CmdStr:   "echo Hello world!"
+            ExitCode: 0
+            Output: """
+                Hello world!
+
+                """
+            ComparisonOutput: """
+                Hello world!
+
+                """
+        }, {
             Negated:  false
             CmdStr:   "go version"
             ExitCode: 0
@@ -9179,7 +9194,7 @@ Steps: {
         }]
     }
 }
-Hash: "68e5331fc3739dfadefe321096e50621ed3f505e11283a4599597c9033a9b384"
+Hash: "60ebf1b2d3797ee0c00965521236865aadc2ee138fb7e34ac856c0ecd9d7312f"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -14940,6 +14955,9 @@ import "strings"
                     run:  "./_scripts/macCISetup.sh"
                     if:   "${{ matrix.os == 'macos-latest' }}"
                 }, {
+                    name: "Docker login"
+                    run:  "docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN"
+                }, {
                     name: "Ensure docker setup"
                     run:  "./_scripts/ensureDocker.sh"
                 }, {
@@ -15009,6 +15027,13 @@ import "strings"
         #shell: string | "bash" | "pwsh" | "python" | "sh" | "cmd" | "powershell"
         #types: [_]
         on: {
+            push: {
+                branches: ["main"]
+                tags: ["v*"]
+            }
+            pull_request: {
+                branches: ["**"]
+            }
             schedule: [{
                 cron: "0 9 * * *"
             }]
@@ -15047,6 +15072,9 @@ import "strings"
                     name: "mac CI setup"
                     run:  "./_scripts/macCISetup.sh"
                     if:   "${{ matrix.os == 'macos-latest' }}"
+                }, {
+                    name: "Docker login"
+                    run:  "docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN"
                 }, {
                     name: "Ensure docker setup"
                     run:  "./_scripts/ensureDocker.sh"
@@ -15196,6 +15224,9 @@ import "strings"
                 run:  "./_scripts/macCISetup.sh"
                 if:   "${{ matrix.os == 'macos-latest' }}"
             }, {
+                name: "Docker login"
+                run:  "docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN"
+            }, {
                 name: "Ensure docker setup"
                 run:  "./_scripts/ensureDocker.sh"
             }, {
@@ -15306,6 +15337,9 @@ test: {
                 run:  "./_scripts/macCISetup.sh"
                 if:   "${{ matrix.os == 'macos-latest' }}"
             }, {
+                name: "Docker login"
+                run:  "docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN"
+            }, {
                 name: "Ensure docker setup"
                 run:  "./_scripts/ensureDocker.sh"
             }, {
@@ -15373,6 +15407,13 @@ testmac: {
     #shell: string | "bash" | "pwsh" | "python" | "sh" | "cmd" | "powershell"
     #types: [_]
     on: {
+        push: {
+            branches: ["main"]
+            tags: ["v*"]
+        }
+        pull_request: {
+            branches: ["**"]
+        }
         schedule: [{
             cron: "0 9 * * *"
         }]
@@ -15411,6 +15452,9 @@ testmac: {
                 name: "mac CI setup"
                 run:  "./_scripts/macCISetup.sh"
                 if:   "${{ matrix.os == 'macos-latest' }}"
+            }, {
+                name: "Docker login"
+                run:  "docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN"
             }, {
                 name: "Ensure docker setup"
                 run:  "./_scripts/ensureDocker.sh"

--- a/guides/2020-11-08-retract-module-versions/go116_en_log.txt
+++ b/guides/2020-11-08-retract-module-versions/go116_en_log.txt
@@ -1,3 +1,5 @@
+$ echo Hello world!
+Hello world!
 $ go version
 go version go1.16 linux/amd64
 $ mkdir /home/gopher/proverb

--- a/guides/2020-11-08-retract-module-versions/guide.cue
+++ b/guides/2020-11-08-retract-module-versions/guide.cue
@@ -44,6 +44,7 @@ Terminals: term1: preguide.#Terminal & {
 
 Steps: goversion: preguide.#Command & {
 	Source: """
+		echo Hello world!
 		go version
 		"""
 }

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -135,6 +135,18 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
+			CmdStr:   "echo Hello world!"
+			ExitCode: 0
+			Output: """
+				Hello world!
+
+				"""
+			ComparisonOutput: """
+				Hello world!
+
+				"""
+		}, {
+			Negated:  false
 			CmdStr:   "go version"
 			ExitCode: 0
 			Output: """
@@ -1403,5 +1415,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "68e5331fc3739dfadefe321096e50621ed3f505e11283a4599597c9033a9b384"
+Hash: "60ebf1b2d3797ee0c00965521236865aadc2ee138fb7e34ac856c0ecd9d7312f"
 Delims: ["{{{", "}}}"]

--- a/internal/ci/workflows.cue
+++ b/internal/ci/workflows.cue
@@ -50,6 +50,10 @@ _#latestGo:     "1.16.3"
 				if:   "${{ matrix.os == 'macos-latest' }}"
 			},
 			{
+				name: "Docker login"
+				run:  "docker login -u $DOCKER_HUB_USER -p $DOCKER_HUB_TOKEN"
+			},
+			{
 				name: "Ensure docker setup"
 				run:  "./_scripts/ensureDocker.sh"
 			},
@@ -124,7 +128,14 @@ test: {
 testmac: {
 	name: "TestMac"
 	#testWorkflow
-	on: schedule: [{cron: "0 9 * * *"}]
+	on: {
+		push: {
+			branches: ["main"]
+			tags: ["v*"]
+		}
+		pull_request: branches: ["**"]
+		schedule: [{cron: "0 9 * * *"}]
+	}
 	jobs: test: strategy: matrix: os: ["macos-latest"]
 }
 


### PR DESCRIPTION
The macOS machines that run as part of GitHub workflows fall outside of
the agreement that GitHub have with Docker. Hence we need to
authenticate our requests with Docker so that docker pulls etc that
happen as part of a CI run are authenticated in all cases.