### PR TITLE
guides: switch to using go1.19 as the guide image

### DIFF
--- a/_posts/2018-10-19-go-fundamentals_go115_en.markdown
+++ b/_posts/2018-10-19-go-fundamentals_go115_en.markdown
@@ -43,7 +43,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### Create a module that others can use
@@ -85,7 +85,7 @@ other code.  The file you just created includes only the name of your module and
 <pre data-command-src="Y2F0IGdvLm1vZAo="><code class="language-.term1">$ cat go.mod
 module &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;
 
-go 1.15
+go 1.19
 </code></pre>
 
 As you add dependencies -- meaning packages from other modules -- the `go.mod` file will list the specific module
@@ -183,7 +183,7 @@ Declare a dependency on `{% raw %}{{{.GREETINGS}}}{% endraw %}` using [`go get`]
 
 <pre data-command-src="Z28gZ2V0IHt7ey5HUkVFVElOR1N9fX0K"><code class="language-.term1">$ go get &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;
 go: downloading &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
-go: &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; upgrade =&gt; v0.0.0-20060102150405-abcedf12345
+go: added &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
 </code></pre>
 
 Without any version specified, `go get` will retrieve the latest version of the `greetings` module. And
@@ -304,8 +304,8 @@ improve the proxy's caching and serving latencies, new versions may not show up 
 not resolve a stale latest version, use the latest commit of the `greetings` module as an explicit version:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5HUkVFVElOR1N9fX1AJGdyZWV0aW5nc19lcnJvcl9jb21taXQK"><code class="language-.term1">$ go get &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;@$greetings_error_commit
-go: &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345 =&gt; v0.0.0-20060102150405-abcedf12345
 go: downloading &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
+go: upgraded &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345 =&gt; v0.0.0-20060102150405-abcedf12345
 </code></pre>
 
 In your hello.go, handle the error now returned by the `Hello` function, along with the non-error value:
@@ -464,8 +464,8 @@ Return to the `hello` module directory and use this new version:
 
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2hlbGxvCmdvIGdldCB7e3suR1JFRVRJTkdTfX19QCRncmVldGluZ3NfcmFuZG9tX2NvbW1pdAo="><code class="language-.term1">$ cd /home/gopher/hello
 $ go get &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;@$greetings_random_commit
-go: &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345 =&gt; v0.0.0-20060102150405-abcedf12345
 go: downloading &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
+go: upgraded &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345 =&gt; v0.0.0-20060102150405-abcedf12345
 </code></pre>
 
 Re-add Gladys's name as an argument to the `Hello` function call in `hello.go`:
@@ -629,9 +629,9 @@ We can see the result in the `hello` module `go.mod` file:
 <pre data-command-src="Y2F0IGdvLm1vZAo="><code class="language-.term1">$ cat go.mod
 module &#123;&#123;&#123;.HELLO&#125;&#125;&#125;
 
-go 1.15
+go 1.19
 
-require &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
+require &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345 // indirect
 
 replace &#123;&#123;&#123;.GREETINGS&#125;&#125;&#125; =&gt; /home/gopher/greetings
 </code></pre>
@@ -753,14 +753,14 @@ The tests should pass:
 
 <pre data-command-src="Z28gdGVzdApnbyB0ZXN0IC12Cg=="><code class="language-.term1">$ go test
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.001s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.001s
 </code></pre>
 
 You will now break the `greetings.Hello` function to view a failing test. The `TestHelloName` test function
@@ -845,7 +845,7 @@ a lot of tests. The `TestHelloName` test should fail -- `TestHelloEmpty` still p
     greetings_test.go:15: Hello(&#34;Gladys&#34;) = &#34;Hail, %v! Well met!&#34;, &lt;nil&gt;, want match for `\bGladys\b`, &lt;nil&gt;
 FAIL
 exit status 1
-FAIL	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.001s
+FAIL	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
 </code></pre>
 
 Let's restore `greetings.Hello` to a working state
@@ -919,7 +919,7 @@ And re-run `go test` to verify our change:
 
 <pre data-command-src="Z28gdGVzdAo="><code class="language-.term1">$ go test
 PASS
-ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.001s
+ok  	&#123;&#123;&#123;.GREETINGS&#125;&#125;&#125;	0.002s
 </code></pre>
 
 This section introduced Go's built-in support for unit testing. In the next section, you'll see how to compile and

--- a/_posts/2019-10-15-get-started-with-go_go115_en.markdown
+++ b/_posts/2019-10-15-get-started-with-go_go115_en.markdown
@@ -29,7 +29,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### Write some code
@@ -117,6 +117,8 @@ code will be in (here, just use `hello`):
 
 <pre data-command-src="Z28gbW9kIGluaXQgaGVsbG8K"><code class="language-.term1">$ go mod init hello
 go: creating new go.mod: module hello
+go: to add module requirements and sums:
+	go mod tidy
 </code></pre>
 
 Our `main` package now belongs to the `hello` module.
@@ -127,6 +129,9 @@ We need to declare a dependency on the `rsc.io/quote` module, specifically versi
 go: downloading rsc.io/quote v1.5.2
 go: downloading rsc.io/sampler v1.3.0
 go: downloading golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+go: added golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+go: added rsc.io/quote v1.5.2
+go: added rsc.io/sampler v1.3.0
 </code></pre>
 
 [`go get`](https://golang.org/cmd/go/#hdr-Add_dependencies_to_current_module_and_install_them) resolves and adds

--- a/_posts/2020-08-13-installing-go_go115_en.markdown
+++ b/_posts/2020-08-13-installing-go_go115_en.markdown
@@ -36,12 +36,12 @@ Start in your home directory:
 
 Download the latest version of Go:
 
-<pre data-command-src="d2dldCAtcSBodHRwczovL2dvbGFuZy5vcmcvZGwvZ28xLjE1LjE1LmxpbnV4LSRHT0FSQ0gudGFyLmd6Cg=="><code class="language-.term1">$ wget -q https://golang.org/dl/go1.15.15.linux-$GOARCH.tar.gz
+<pre data-command-src="d2dldCAtcSBodHRwczovL2dvbGFuZy5vcmcvZGwvZ28xLjE5LjEubGludXgtJEdPQVJDSC50YXIuZ3oK"><code class="language-.term1">$ wget -q https://golang.org/dl/go1.19.1.linux-$GOARCH.tar.gz
 </code></pre>
 
 Extract and install:
 
-<pre data-command-src="c3VkbyB0YXIgLUMgL3Vzci9sb2NhbCAteHpmIGdvMS4xNS4xNS5saW51eC0kR09BUkNILnRhci5nego="><code class="language-.term1">$ sudo tar -C /usr/local -xzf go1.15.15.linux-$GOARCH.tar.gz
+<pre data-command-src="c3VkbyB0YXIgLUMgL3Vzci9sb2NhbCAteHpmIGdvMS4xOS4xLmxpbnV4LSRHT0FSQ0gudGFyLmd6Cg=="><code class="language-.term1">$ sudo tar -C /usr/local -xzf go1.19.1.linux-$GOARCH.tar.gz
 </code></pre>
 
 Add the install target to your profile `PATH`:
@@ -57,7 +57,7 @@ Source your profile to test the new settings:
 Verify the Go installation:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### The Go environment
@@ -75,6 +75,7 @@ GOBIN=&#34;&#34;
 GOCACHE=&#34;/home/gopher/.cache/go-build&#34;
 GOENV=&#34;/home/gopher/.config/go/env&#34;
 GOEXE=&#34;&#34;
+GOEXPERIMENT=&#34;&#34;
 GOFLAGS=&#34;&#34;
 GOHOSTARCH=&#34;amd64&#34;
 GOHOSTOS=&#34;linux&#34;
@@ -90,19 +91,21 @@ GOROOT=&#34;/usr/local/go&#34;
 GOSUMDB=&#34;sum.golang.org&#34;
 GOTMPDIR=&#34;&#34;
 GOTOOLDIR=&#34;/usr/local/go/pkg/tool/linux_amd64&#34;
+GOVCS=&#34;&#34;
+GOVERSION=&#34;go1.19.1&#34;
 GCCGO=&#34;gccgo&#34;
 AR=&#34;ar&#34;
 CC=&#34;gcc&#34;
 CXX=&#34;g++&#34;
 CGO_ENABLED=&#34;1&#34;
-GOMOD=&#34;&#34;
+GOMOD=&#34;/dev/null&#34;
+GOWORK=&#34;&#34;
 CGO_CFLAGS=&#34;-g -O2&#34;
 CGO_CPPFLAGS=&#34;&#34;
 CGO_CXXFLAGS=&#34;-g -O2&#34;
 CGO_FFLAGS=&#34;-g -O2&#34;
 CGO_LDFLAGS=&#34;-g -O2&#34;
 PKG_CONFIG=&#34;pkg-config&#34;
-GOGCCFLAGS=&#34;fake_gcc_flags&#34;
 </code></pre>
 
 To see the effective setting of a specific variable, for example `GOBIN`, you can run:

--- a/_posts/2020-09-01-basic-go-modules-example_go115_en.markdown
+++ b/_posts/2020-09-01-basic-go-modules-example_go115_en.markdown
@@ -51,7 +51,7 @@ $ go mod init mod.com
 go: creating new go.mod: module mod.com
 $ go get &#123;&#123;&#123;.REPO1&#125;&#125;&#125;
 go: downloading &#123;&#123;&#123;.REPO1&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
-go: &#123;&#123;&#123;.REPO1&#125;&#125;&#125; upgrade =&gt; v0.0.0-20060102150405-abcedf12345
+go: added &#123;&#123;&#123;.REPO1&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
 $ go run &#123;&#123;&#123;.REPO1&#125;&#125;&#125;
 Hello, world!
 </code></pre>

--- a/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
+++ b/_posts/2020-11-05-tools-as-dependencies_go115_en.markdown
@@ -33,7 +33,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### Why `stringer`?
@@ -186,11 +186,13 @@ exists solely for its side effects, in this case the declaration of the dependen
 With the package dependency declared, you can now add a dependency on the module that contains
 `golang.org/x/tools/cmd/stringer`. Use `go get` to add a dependency:
 
-<pre data-command-src="Z28gZ2V0IGdvbGFuZy5vcmcveC90b29scy9jbWQvc3RyaW5nZXJAdjAuMC4wLTIwMjAxMTA1MjIwMzEwLTc4YjE1ODU4NTM2MAo="><code class="language-.term1">$ go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/mod v0.3.0
-go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+<pre data-command-src="Z28gZ2V0IGdvbGFuZy5vcmcveC90b29scy9jbWQvc3RyaW5nZXJAdjAuMS4xMy0wLjIwMjIwOTE3MDA0NTQxLTRkMTg5MjNmMDYwZQo="><code class="language-.term1">$ go get golang.org/x/tools/cmd/stringer@v0.1.13-0.20220917004541-4d18923f060e
+go: downloading golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
+go: downloading golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+go: added golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+go: added golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+go: added golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
 </code></pre>
 
 You can see your new dependency in the project's `go.mod` file:
@@ -198,9 +200,13 @@ You can see your new dependency in the project's `go.mod` file:
 <pre data-command-src="Y2F0IGdvLm1vZAo="><code class="language-.term1">$ cat go.mod
 module painkiller
 
-go 1.15
+go 1.19
 
-require golang.org/x/tools v0.0.0-20201105220310-78b158585360 // indirect
+require (
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e // indirect
+)
 </code></pre>
 
 This guide uses a specific version of `stringer` so as to remain reproducible. In a real-world project you would almost

--- a/_posts/2020-11-08-retract-module-versions_go116_en.markdown
+++ b/_posts/2020-11-08-retract-module-versions_go116_en.markdown
@@ -48,7 +48,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.16.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### The `proverb` module
@@ -132,7 +132,7 @@ Add a dependency on the `{% raw %}{{{.PROVERB}}}{% endraw %}` module:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QHYwLjEuMAo="><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.1.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0
-go get: added &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0
+go: added &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0
 </code></pre>
 
 Run to make sure everything works:
@@ -187,7 +187,7 @@ try this out:
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpnbyBnZXQge3t7LlBST1ZFUkJ9fX1AdjAuMi4wCmdvIHJ1biAuCg=="><code class="language-.term1">$ cd /home/gopher/gopher
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0 =&gt; v0.2.0
+go: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.1.0 =&gt; v0.2.0
 $ go run .
 Concurrency is parallelism.
 </code></pre>
@@ -223,7 +223,7 @@ Inspect the `go.mod` to see the result:
 <pre data-command-src="Y2F0IGdvLm1vZAo="><code class="language-.term1">$ cat go.mod
 module &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;
 
-go 1.16
+go 1.19
 
 retract v0.2.0
 </code></pre>
@@ -270,7 +270,7 @@ Return to your `gopher` module to use this new version:
 <pre data-command-src="Y2QgL2hvbWUvZ29waGVyL2dvcGhlcgpnbyBnZXQge3t7LlBST1ZFUkJ9fX1AdjAuMy4wCg=="><code class="language-.term1">$ cd /home/gopher/gopher
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.3.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0 =&gt; v0.3.0
+go: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0 =&gt; v0.3.0
 </code></pre>
 
 This step also ensures that [proxy.golang.org](https://proxy.golang.org/) is now aware of `v0.3.0`.
@@ -324,7 +324,7 @@ So what would happen if you were to rely on the now retracted `v0.2.0`?
 go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.2.0: retracted by module author: Go proverb was totally wrong
 go: to switch to the latest unretracted version, run:
 	go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest
-go get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v0.2.0
+go: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v0.2.0
 </code></pre>
 
 A helpful message is printed, warning that you are now depending on a retracted version. Notice that this error message
@@ -349,7 +349,7 @@ gopher
 Let's follow the advice of the warning message, and return to the latest un-retracted version:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUk9WRVJCfX19QGxhdGVzdAo="><code class="language-.term1">$ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0 =&gt; v0.3.0
+go: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.2.0 =&gt; v0.3.0
 </code></pre>
 
 ### Another type of proverb
@@ -450,16 +450,16 @@ go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0
 go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.0: retracted by module author: Published v1 too early
 go: to switch to the latest unretracted version, run:
 	go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v1.0.0
+go: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.3.0 =&gt; v1.0.0
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1
 go: warning: &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v1.0.1: retracted by module author: Published v1 too early
 go: to switch to the latest unretracted version, run:
 	go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@latest
-go get: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0 =&gt; v1.0.1
+go: upgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.0 =&gt; v1.0.1
 $ go get &#123;&#123;&#123;.PROVERB&#125;&#125;&#125;@v0.4.0
 go: downloading &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v0.4.0
-go get: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1 =&gt; v0.4.0
+go: downgraded &#123;&#123;&#123;.PROVERB&#125;&#125;&#125; v1.0.1 =&gt; v0.4.0
 </code></pre>
 
 _Note: you might not see the warning about either `v1.0.0` or `v1.0.1` being

--- a/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
+++ b/_posts/2020-11-09-installing-go-programs-directly_go116_en.markdown
@@ -14,7 +14,7 @@ and tool author._
 Users need a simple, easy-to-remember way to install Go programs. Similarly, tool authors need a short one-liner they
 can include at the top of their `README.md` explaining how to install the tool.
 
-Go 1.16 introduces a new way to install Go programs directly with the `go` command. This guide
+Go 1.16 introduced a new way to install Go programs directly with the `go` command. This guide
 introduces the new mode of `go install` using the example of
 [`filippo.io/mkcert`](https://filippo.io/mkcert), and is suitable for both end users and tool authors.
 
@@ -27,60 +27,23 @@ You should already have completed:
 This guide is running with:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.16.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
-
-### Background
-
-Currently, tool authors who want to provide installation instructions in their projects' `README.md` typically include:
-
-<pre data-command-src="Z28gZ2V0IGZpbGlwcG8uaW8vbWtjZXJ0QHYxLjQuMgo="><code class="language-.term1">$ go get filippo.io/mkcert@v1.4.2
-go: downloading filippo.io/mkcert v1.4.2
-go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
-go: downloading honnef.co/go/tools v0.0.0-20191107024926-a9480a3ec3bc
-go: downloading howett.net/plist v0.0.0-20181124034731-591f970eefbb
-go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-go: downloading golang.org/x/text v0.3.0
-go: downloading github.com/BurntSushi/toml v0.3.1
-</code></pre>
-
-_Note: most `README.md` instructions that use `go get` do not specify a version. This results in the latest
-version of a package being fetched. A specific version, `v1.4.2`, is used here to ensure this guide
-remains reproducible._
-
-There are a number of problems with this approach:
-
-* A user might run the above `go get` within a module, which would
-  update the current module's dependencies, rather than just installing the tool directly.
-* `go get` might not be running in module mode at all, for example
-  if the user previously modified `GO111MODULE`.
-* The use of `go get` is confusing; it is used to download and install executables,
-  but it's also responsible for managing dependencies in `go.mod` files.
-
-Prior to Go 1.16, the general advice to fix the first two problems was to use a snippet
-which runs `go get` in module mode and outside any module, by using a temporary directory:
-
-<pre data-command-src="KGNkICQobWt0ZW1wIC1kKTsgR08xMTFNT0RVTEU9b24gZ28gZ2V0IGZpbGlwcG8uaW8vbWtjZXJ0QHYxLjQuMikK"><code class="language-.term1">$ (cd $(mktemp -d); GO111MODULE=on go get filippo.io/mkcert@v1.4.2)
-</code></pre>
-
-However, this new approach had its own problems:
-
-* It's not user-friendly; the extra shell is confusing to newcomers, and hard to remember.
-* It's not cross platform; the command is not guaranteed to work on Windows.
-
-It is clear that neither method is satisfactory, especially for `README.md`
-instructions which are meant to be brief and easy to follow.
 
 ### `go install` in Go 1.16
 
-In Go 1.16, the `go install` command is now used to install programs directly, i.e. regardless of the current
-module context:
+As of Go 1.16, the `go install` command is now used to install
+programs directly, i.e. regardless of the current module context:
 
-<pre data-command-src="Z28gaW5zdGFsbCBmaWxpcHBvLmlvL21rY2VydEB2MS40LjIK"><code class="language-.term1">$ go install filippo.io/mkcert@v1.4.2
+<pre data-command-src="Z28gaW5zdGFsbCBmaWxpcHBvLmlvL21rY2VydEB2MS40LjQK"><code class="language-.term1">$ go install filippo.io/mkcert@v1.4.4
+go: downloading filippo.io/mkcert v1.4.4
+go: downloading golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+go: downloading software.sslmate.com/src/go-pkcs12 v0.2.0
+go: downloading golang.org/x/text v0.3.7
+go: downloading golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
 </code></pre>
 
-For the purposes of this guide you are using a specific version (`v1.4.2`). Alternatively,
+For the purposes of this guide you are using a specific version (`v1.4.4`). Alternatively,
 the special `latest` version can be used to install the latest release.
 
 Much like the previous behaviour of `go get`, `go install` places binaries in `$GOPATH/bin`,
@@ -96,18 +59,19 @@ Verify that `mkcert` is now on your `PATH`:
 Run `mkcert` to check everything is working:
 
 <pre data-command-src="bWtjZXJ0IC12ZXJzaW9uCg=="><code class="language-.term1">$ mkcert -version
-v1.4.2
+v1.4.4
 </code></pre>
 
 You can also use `go version` to see the module dependencies used in building the program:
 
 <pre data-command-src="Z28gdmVyc2lvbiAtbSAkKHdoaWNoIG1rY2VydCkK"><code class="language-.term1">$ go version -m $(which mkcert)
-/home/gopher/go/bin/mkcert: go1.16.15
+/home/gopher/go/bin/mkcert: go1.19.1
 	path	filippo.io/mkcert
-	mod	filippo.io/mkcert	v1.4.2	h1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
-	dep	golang.org/x/net	v0.0.0-20190620200207-3b0461eec859	h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-	dep	golang.org/x/text	v0.3.0	h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-	dep	software.sslmate.com/src/go-pkcs12	v0.0.0-20180114231543-2291e8f0f237	h1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
+	mod	filippo.io/mkcert	v1.4.4	h1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
+	dep	golang.org/x/crypto	v0.0.0-20220331220935-ae2d96664a29	h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+	dep	golang.org/x/net	v0.0.0-20220421235706-1d1ef9303861	h1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+	dep	golang.org/x/text	v0.3.7	h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+	dep	software.sslmate.com/src/go-pkcs12	v0.2.0	h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
 </code></pre>
 
 To eliminate redundancy and confusion, using `go get` to build or
@@ -115,7 +79,7 @@ install programs is being deprecated in Go 1.16.
 
 ### Conclusion
 
-That's it! Time to sit back and wait for the release of Go 1.16!
+That's it!
 
 As a next step you might like to consider:
 

--- a/_posts/2020-11-09-using-staticcheck_go115_en.markdown
+++ b/_posts/2020-11-09-using-staticcheck_go115_en.markdown
@@ -36,7 +36,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### Installing Staticcheck
@@ -46,15 +46,16 @@ module dependency, please see the ["Developer tools as module dependencies" guid
 
 Use `go get` to install Staticcheck:
 
-<pre data-command-src="KGNkICQobWt0ZW1wIC1kKTsgR08xMTFNT0RVTEU9b24gZ28gZ2V0IGhvbm5lZi5jby9nby90b29scy9jbWQvc3RhdGljY2hlY2tAdjAuMC4xLTIwMjAuMS42KQo="><code class="language-.term1">$ (cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)
-go: downloading honnef.co/go/tools v0.0.1-2020.1.6
-go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6
-go: downloading golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef
-go: downloading github.com/BurntSushi/toml v0.3.1
-go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+<pre data-command-src="Z28gaW5zdGFsbCBob25uZWYuY28vZ28vdG9vbHMvY21kL3N0YXRpY2NoZWNrQHYwLjMuMwo="><code class="language-.term1">$ go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+go: downloading honnef.co/go/tools v0.3.3
+go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+go: downloading golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
+go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+go: downloading github.com/BurntSushi/toml v0.4.1
+go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 </code></pre>
 
-_Note: so that this guide remains reproducible we have spcified an explicit version, `v0.0.1-2020.1.6`.
+_Note: so that this guide remains reproducible we have spcified an explicit version, `v0.3.3`.
 When running yourself you could use the special version `latest`._
 
 The rather ugly use of a temporary directory ensures that `go get` is run outside of a module.  See the
@@ -69,7 +70,7 @@ Check that `staticcheck` is on your `PATH`:
 Run `staticcheck` as a quick check:
 
 <pre data-command-src="c3RhdGljY2hlY2sgLXZlcnNpb24K"><code class="language-.term1">$ staticcheck -version
-staticcheck 2020.1.6
+staticcheck 2022.1.3 (v0.3.3)
 </code></pre>
 
 You're all set!
@@ -164,6 +165,8 @@ Invalid Printf call
 Available since
     2019.2
 
+Online documentation
+    https://staticcheck.io/docs/checks#SA5009
 </code></pre>
 
 Let's consider one of the problems reported, [`ST1006`](https://staticcheck.io/docs/checks#ST1006), documented as "Poorly

--- a/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
+++ b/_posts/2020-11-12-working-with-private-modules_go115_en.markdown
@@ -32,7 +32,7 @@ You should already have completed:
 This guide is running using:
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### The `public` and `private` modules
@@ -166,7 +166,7 @@ Add a dependency on the `public` module:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QVUJMSUN9fX0K"><code class="language-.term1">$ go get &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125;
 go: downloading &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
-go: &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; upgrade =&gt; v0.0.0-20060102150405-abcedf12345
+go: added &#123;&#123;&#123;.PUBLIC&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
 </code></pre>
 
 As expected, that succeeded.
@@ -174,7 +174,7 @@ As expected, that succeeded.
 Try to add a dependency on the `private` module:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUklWQVRFfX19Cg=="><code class="language-.term1">$ go get &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;
-go get &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;: module &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;: reading https://proxy.golang.org/&#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;/@v/list: 404 Not Found
+go: module &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;: reading https://proxy.golang.org/&#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;/@v/list: 404 Not Found
 	server response:
 	not found: module &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for &#39;https://gopher.live&#39;: terminal prompts disabled
@@ -193,7 +193,7 @@ And try once again to add a dependency on the `private` module:
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUklWQVRFfX19Cg=="><code class="language-.term1">$ go get &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;
 go: downloading &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
-go get &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;: &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: verifying module: &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/&#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: 404 Not Found
+go: &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: verifying module: &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/&#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: 404 Not Found
 	server response:
 	not found: &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;@v0.0.0-20060102150405-abcedf12345: invalid version: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for &#39;https://gopher.live&#39;: terminal prompts disabled
@@ -223,7 +223,7 @@ succeeded):
 
 <pre data-command-src="Z28gZ2V0IHt7ey5QUklWQVRFfX19Cg=="><code class="language-.term1">$ go get &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125;
 go: downloading &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
-go: &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125; upgrade =&gt; v0.0.0-20060102150405-abcedf12345
+go: added &#123;&#123;&#123;.PRIVATE&#125;&#125;&#125; v0.0.0-20060102150405-abcedf12345
 </code></pre>
 
 Success! As a final check, run the `gopher` module `main` package:
@@ -234,11 +234,11 @@ private.Secret(): This is a top secret message... for your eyes only
 </code></pre>
 
 For more details on the `GOPRIVATE` environment variable and the values it can take, see
-`go help module-private`, which also includes examples of how to use the `*` glob to match multiple sub domains
+`go help module-auth`, which also includes examples of how to use the `*` glob to match multiple sub domains
 or modules.
 
 The `GONOPROXY` and `GONOSUMDB` environment variables can be used for more fine
-grained control. Again, see `go help module-private` for more information.
+grained control. Again, see `go help module-auth` for more information.
 
 ### Conclusion
 

--- a/_posts/2020-11-19-major-version-repository-structure_go115_en.markdown
+++ b/_posts/2020-11-19-major-version-repository-structure_go115_en.markdown
@@ -23,7 +23,7 @@ In this guide you will:
 ### Context
 
 <pre data-command-src="Z28gdmVyc2lvbgo="><code class="language-.term1">$ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 </code></pre>
 
 ### Major branch strategy
@@ -165,12 +165,16 @@ func main() &#123;
 
 <pre data-command-src="Z28gZ2V0IHt7ey5CUkFOQ0h9fX1AdjEuMC4wCmdvIGdldCB7e3suQlJBTkNIfX19L3YyQHYyLjAuMApnbyBnZXQge3t7LlNVQkRJUn19fUB2MS4wLjAKZ28gZ2V0IHt7ey5TVUJESVJ9fX0vdjJAdjIuMC4wCg=="><code class="language-.term1">$ go get &#123;&#123;&#123;.BRANCH&#125;&#125;&#125;@v1.0.0
 go: downloading &#123;&#123;&#123;.BRANCH&#125;&#125;&#125; v1.0.0
+go: added &#123;&#123;&#123;.BRANCH&#125;&#125;&#125; v1.0.0
 $ go get &#123;&#123;&#123;.BRANCH&#125;&#125;&#125;/v2@v2.0.0
 go: downloading &#123;&#123;&#123;.BRANCH&#125;&#125;&#125;/v2 v2.0.0
+go: added &#123;&#123;&#123;.BRANCH&#125;&#125;&#125;/v2 v2.0.0
 $ go get &#123;&#123;&#123;.SUBDIR&#125;&#125;&#125;@v1.0.0
 go: downloading &#123;&#123;&#123;.SUBDIR&#125;&#125;&#125; v1.0.0
+go: added &#123;&#123;&#123;.SUBDIR&#125;&#125;&#125; v1.0.0
 $ go get &#123;&#123;&#123;.SUBDIR&#125;&#125;&#125;/v2@v2.0.0
 go: downloading &#123;&#123;&#123;.SUBDIR&#125;&#125;&#125;/v2 v2.0.0
+go: added &#123;&#123;&#123;.SUBDIR&#125;&#125;&#125;/v2 v2.0.0
 </code></pre>
 
 <pre data-command-src="Z28gcnVuIC4K"><code class="language-.term1">$ go run .

--- a/cue.mod/tests/eval.txt
+++ b/cue.mod/tests/eval.txt
@@ -17,7 +17,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -50,7 +50,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -83,7 +83,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -101,7 +101,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -119,7 +119,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go116: {
-                Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -148,7 +148,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go116: {
-                Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -177,7 +177,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -206,7 +206,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -235,7 +235,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -253,7 +253,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/installgo1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/installgo1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -271,7 +271,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -304,7 +304,7 @@ Delims: ["{{{", "}}}"]
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }]
@@ -402,7 +402,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -1756,8 +1756,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -1807,7 +1807,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -1830,8 +1830,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     pwd_home: {
@@ -1911,13 +1911,13 @@ Steps: {
             Output: """
                 module {{{.GREETINGS}}}
 
-                go 1.15
+                go 1.19
 
                 """
             ComparisonOutput: """
                 module {{{.GREETINGS}}}
 
-                go 1.15
+                go 1.19
 
                 """
         }]
@@ -2119,13 +2119,13 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.GREETINGS}}} upgrade => v0.0.0-20060102150405-abcedf12345
+                go: added {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
                 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.GREETINGS}}} upgrade => v0.0.0-20060102150405-abcedf12345
                 """
         }]
     }
@@ -2390,14 +2390,14 @@ Steps: {
             CmdStr:   "go get {{{.GREETINGS}}}@$greetings_error_commit"
             ExitCode: 0
             Output: """
-                go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
                 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+                go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
                 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
+                go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
                 """
         }]
     }
@@ -2704,14 +2704,14 @@ Steps: {
             CmdStr:   "go get {{{.GREETINGS}}}@$greetings_random_commit"
             ExitCode: 0
             Output: """
-                go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
                 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+                go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
                 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
+                go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
                 """
         }]
     }
@@ -3026,9 +3026,9 @@ Steps: {
             Output: """
                 module {{{.HELLO}}}
 
-                go 1.15
+                go 1.19
 
-                require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+                require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 // indirect
 
                 replace {{{.GREETINGS}}} => /home/gopher/greetings
 
@@ -3036,9 +3036,9 @@ Steps: {
             ComparisonOutput: """
                 module {{{.HELLO}}}
 
-                go 1.15
+                go 1.19
 
-                require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+                require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 // indirect
 
                 replace {{{.GREETINGS}}} => /home/gopher/greetings
 
@@ -3207,7 +3207,7 @@ Steps: {
             ExitCode: 0
             Output: """
                 PASS
-                ok  \t{{{.GREETINGS}}}\t0.002s
+                ok  \t{{{.GREETINGS}}}\t0.001s
 
                 """
             ComparisonOutput: """
@@ -3225,7 +3225,7 @@ Steps: {
                 === RUN   TestHelloEmpty
                 --- PASS: TestHelloEmpty (0.00s)
                 PASS
-                ok  \t{{{.GREETINGS}}}\t0.002s
+                ok  \t{{{.GREETINGS}}}\t0.001s
 
                 """
             ComparisonOutput: """
@@ -3399,7 +3399,7 @@ Steps: {
                     greetings_test.go:15: Hello("Gladys") = "Hail, %v! Well met!", <nil>, want match for `\\bGladys\\b`, <nil>
                 FAIL
                 exit status 1
-                FAIL\t{{{.GREETINGS}}}\t0.001s
+                FAIL\t{{{.GREETINGS}}}\t0.002s
 
                 """
             ComparisonOutput: """
@@ -3569,7 +3569,7 @@ Steps: {
             ExitCode: 0
             Output: """
                 PASS
-                ok  \t{{{.GREETINGS}}}\t0.001s
+                ok  \t{{{.GREETINGS}}}\t0.002s
 
                 """
             ComparisonOutput: """
@@ -3673,7 +3673,7 @@ Steps: {
         }]
     }
 }
-Hash: "4030ef2161a08fd4057fffd4499e5b683247d45a04169c7cf11892d42c9f2138"
+Hash: "5eaa4bac4c0d61559e4ada00c264ad04e45e2b4635a313f9596008eef77a880e"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -3739,7 +3739,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -3863,7 +3863,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -3886,8 +3886,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     pwd_home: {
@@ -4020,10 +4020,14 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: creating new go.mod: module hello
+                go: to add module requirements and sums:
+                \tgo mod tidy
 
                 """
             ComparisonOutput: """
                 go: creating new go.mod: module hello
+                go: to add module requirements and sums:
+                \tgo mod tidy
 
                 """
         }]
@@ -4043,10 +4047,16 @@ Steps: {
                 go: downloading rsc.io/quote v1.5.2
                 go: downloading rsc.io/sampler v1.3.0
                 go: downloading golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+                go: added golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+                go: added rsc.io/quote v1.5.2
+                go: added rsc.io/sampler v1.3.0
 
                 """
             ComparisonOutput: """
 
+                go: added golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+                go: added rsc.io/quote v1.5.2
+                go: added rsc.io/sampler v1.3.0
                 go: downloading golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
                 go: downloading rsc.io/quote v1.5.2
                 go: downloading rsc.io/sampler v1.3.0
@@ -4075,7 +4085,7 @@ Steps: {
         }]
     }
 }
-Hash: "13b62f3b7d87bd98ecc52b27beabea85d4a954d86f0a1ff3ac75aed4b213b07f"
+Hash: "5deda7db40f740e3769be5cc2e7ac9dff1bb782bf714e5011e9f5d84abab8774"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -4137,7 +4147,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/installgo1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/installgo1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -4155,7 +4165,7 @@ Steps: {
         DoNotTrim:       false
         Name:            string
         StepType:        1
-        Source:          "wget -q https://golang.org/dl/go1.15.15.linux-$GOARCH.tar.gz"
+        Source:          "wget -q https://golang.org/dl/go1.19.1.linux-$GOARCH.tar.gz"
         InformationOnly: false
         Terminal:        string
     }
@@ -4163,7 +4173,7 @@ Steps: {
         DoNotTrim:       false
         Name:            string
         StepType:        1
-        Source:          "sudo tar -C /usr/local -xzf go1.15.15.linux-$GOARCH.tar.gz"
+        Source:          "sudo tar -C /usr/local -xzf go1.19.1.linux-$GOARCH.tar.gz"
         InformationOnly: false
         Terminal:        string
     }
@@ -4294,7 +4304,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/installgo1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/installgo1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -4336,7 +4346,7 @@ Steps: {
         Terminal:        "term1"
         Stmts: [{
             Negated:          false
-            CmdStr:           "wget -q https://golang.org/dl/go1.15.15.linux-$GOARCH.tar.gz"
+            CmdStr:           "wget -q https://golang.org/dl/go1.19.1.linux-$GOARCH.tar.gz"
             ExitCode:         0
             Output:           ""
             ComparisonOutput: ""
@@ -4351,7 +4361,7 @@ Steps: {
         Terminal:        "term1"
         Stmts: [{
             Negated:          false
-            CmdStr:           "sudo tar -C /usr/local -xzf go1.15.15.linux-$GOARCH.tar.gz"
+            CmdStr:           "sudo tar -C /usr/local -xzf go1.19.1.linux-$GOARCH.tar.gz"
             ExitCode:         0
             Output:           ""
             ComparisonOutput: ""
@@ -4398,8 +4408,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     go_env: {
@@ -4420,6 +4430,7 @@ Steps: {
                 GOCACHE="/home/gopher/.cache/go-build"
                 GOENV="/home/gopher/.config/go/env"
                 GOEXE=""
+                GOEXPERIMENT=""
                 GOFLAGS=""
                 GOHOSTARCH="amd64"
                 GOHOSTOS="linux"
@@ -4435,19 +4446,21 @@ Steps: {
                 GOSUMDB="sum.golang.org"
                 GOTMPDIR=""
                 GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
+                GOVCS=""
+                GOVERSION="go1.19.1"
                 GCCGO="gccgo"
                 AR="ar"
                 CC="gcc"
                 CXX="g++"
                 CGO_ENABLED="1"
-                GOMOD=""
+                GOMOD="/dev/null"
+                GOWORK=""
                 CGO_CFLAGS="-g -O2"
                 CGO_CPPFLAGS=""
                 CGO_CXXFLAGS="-g -O2"
                 CGO_FFLAGS="-g -O2"
                 CGO_LDFLAGS="-g -O2"
                 PKG_CONFIG="pkg-config"
-                GOGCCFLAGS="fake_gcc_flags"
 
                 """
             ComparisonOutput: """
@@ -4457,6 +4470,7 @@ Steps: {
                 GOCACHE="/home/gopher/.cache/go-build"
                 GOENV="/home/gopher/.config/go/env"
                 GOEXE=""
+                GOEXPERIMENT=""
                 GOFLAGS=""
                 GOHOSTARCH="amd64"
                 GOHOSTOS="linux"
@@ -4472,19 +4486,21 @@ Steps: {
                 GOSUMDB="sum.golang.org"
                 GOTMPDIR=""
                 GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
+                GOVCS=""
+                GOVERSION="go1.19.1"
                 GCCGO="gccgo"
                 AR="ar"
                 CC="gcc"
                 CXX="g++"
                 CGO_ENABLED="1"
-                GOMOD=""
+                GOMOD="/dev/null"
+                GOWORK=""
                 CGO_CFLAGS="-g -O2"
                 CGO_CPPFLAGS=""
                 CGO_CXXFLAGS="-g -O2"
                 CGO_FFLAGS="-g -O2"
                 CGO_LDFLAGS="-g -O2"
                 PKG_CONFIG="pkg-config"
-                GOGCCFLAGS="fake_gcc_flags"
 
                 """
         }]
@@ -4737,7 +4753,7 @@ Steps: {
         }]
     }
 }
-Hash: "57f9241df49785e337140bd0aa692834aac59089f3b266546b0f3ac12cc7cddc"
+Hash: "6823ef57ddaff8214fd4ab7366db217f74bd29901bda3d8ba0c6b8a283732e24"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -4814,7 +4830,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -4987,8 +5003,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -5038,7 +5054,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -5215,13 +5231,13 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcedf12345
+                go: added {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
                 go: downloading {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcedf12345
                 """
         }, {
             Negated:  false
@@ -5260,7 +5276,7 @@ Steps: {
         }]
     }
 }
-Hash: "703d7b8f9690e147301b8824a58f1fcaadf55bc2cad6ae498ef6ef33db2bf706"
+Hash: "ae3238b78d035abf6fc957d0c603b0506d75a724b225fcfacb127ba4e8f7b810"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -5338,7 +5354,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -5531,8 +5547,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -5582,7 +5598,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -5808,7 +5824,7 @@ Steps: {
         }]
     }
 }
-Hash: "b53dcd3de8b90157ae825182f021b1c7087125438c18e54e2bc618d1e214588a"
+Hash: "772eb554083abcd286edfc7be26d16d0bfefcf7a6740ab3342b60e2609d1e744"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -5891,7 +5907,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -6094,7 +6110,7 @@ Steps: {
         DoNotTrim:       false
         Name:            string
         StepType:        1
-        Source:          "go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360"
+        Source:          "go get golang.org/x/tools/cmd/stringer@v0.1.13-0.20220917004541-4d18923f060e"
         InformationOnly: false
         Terminal:        string
     }
@@ -6353,8 +6369,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -6404,7 +6420,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -6427,8 +6443,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     painkiller_go_mod_init: {
@@ -6676,21 +6692,25 @@ Steps: {
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
-            CmdStr:   "go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360"
+            CmdStr:   "go get golang.org/x/tools/cmd/stringer@v0.1.13-0.20220917004541-4d18923f060e"
             ExitCode: 0
             Output: """
-                go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
-                go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-                go: downloading golang.org/x/mod v0.3.0
-                go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+                go: downloading golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
+                go: downloading golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+                go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+                go: added golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+                go: added golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+                go: added golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
 
                 """
             ComparisonOutput: """
 
-                go: downloading golang.org/x/mod v0.3.0
-                go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
-                go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
-                go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
+                go: added golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+                go: added golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+                go: added golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
+                go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+                go: downloading golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+                go: downloading golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
                 """
         }]
     }
@@ -6708,17 +6728,25 @@ Steps: {
             Output: """
                 module painkiller
 
-                go 1.15
+                go 1.19
 
-                require golang.org/x/tools v0.0.0-20201105220310-78b158585360 // indirect
+                require (
+                \tgolang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+                \tgolang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+                \tgolang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e // indirect
+                )
 
                 """
             ComparisonOutput: """
                 module painkiller
 
-                go 1.15
+                go 1.19
 
-                require golang.org/x/tools v0.0.0-20201105220310-78b158585360 // indirect
+                require (
+                \tgolang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+                \tgolang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+                \tgolang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e // indirect
+                )
 
                 """
         }]
@@ -7065,7 +7093,7 @@ Steps: {
         }]
     }
 }
-Hash: "422eaf5b740efdf4c0016fabc28e2438e057a7108260db3be9edd4787ca4a0ca"
+Hash: "f440fa815f06042623db1e5dcbc6fb91863ff214da8db577281584cb87006d59"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -7153,7 +7181,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go116: {
-                Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -7856,8 +7884,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -7907,7 +7935,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go116: {
-            Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -7930,8 +7958,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.16.15 linux/amd64"
-            ComparisonOutput: "go version go1.16.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     proverb_create: {
@@ -8149,12 +8177,12 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.PROVERB}}} v0.1.0
-                go get: added {{{.PROVERB}}} v0.1.0
+                go: added {{{.PROVERB}}} v0.1.0
 
                 """
             ComparisonOutput: """
 
-                go get: added {{{.PROVERB}}} v0.1.0
+                go: added {{{.PROVERB}}} v0.1.0
                 go: downloading {{{.PROVERB}}} v0.1.0
                 """
         }]
@@ -8322,13 +8350,13 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.PROVERB}}} v0.2.0
-                go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
+                go: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 
                 """
             ComparisonOutput: """
 
-                go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
                 go: downloading {{{.PROVERB}}} v0.2.0
+                go: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
                 """
         }, {
             Negated:  false
@@ -8388,7 +8416,7 @@ Steps: {
             Output: """
                 module {{{.PROVERB}}}
 
-                go 1.16
+                go 1.19
 
                 retract v0.2.0
 
@@ -8396,7 +8424,7 @@ Steps: {
             ComparisonOutput: """
                 module {{{.PROVERB}}}
 
-                go 1.16
+                go 1.19
 
                 retract v0.2.0
 
@@ -8541,13 +8569,13 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.PROVERB}}} v0.3.0
-                go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+                go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 
                 """
             ComparisonOutput: """
 
-                go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
                 go: downloading {{{.PROVERB}}} v0.3.0
+                go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
                 """
         }]
     }
@@ -8644,13 +8672,13 @@ Steps: {
                 go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
                 go: to switch to the latest unretracted version, run:
                 \tgo get {{{.PROVERB}}}@latest
-                go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+                go: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 
                 """
             ComparisonOutput: """
 
                 \tgo get {{{.PROVERB}}}@latest
-                go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+                go: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
                 go: to switch to the latest unretracted version, run:
                 go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
                 """
@@ -8712,12 +8740,12 @@ Steps: {
             CmdStr:   "go get {{{.PROVERB}}}@latest"
             ExitCode: 0
             Output: """
-                go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+                go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 
                 """
             ComparisonOutput: """
 
-                go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+                go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
                 """
         }]
     }
@@ -9028,15 +9056,15 @@ Steps: {
                 go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
                 go: to switch to the latest unretracted version, run:
                 \tgo get {{{.PROVERB}}}@latest
-                go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
+                go: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 
                 """
             ComparisonOutput: """
 
                 \tgo get {{{.PROVERB}}}@latest
-                go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
                 go: downloading {{{.PROVERB}}} v1.0.0
                 go: to switch to the latest unretracted version, run:
+                go: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
                 go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
                 """
         }, {
@@ -9048,15 +9076,15 @@ Steps: {
                 go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
                 go: to switch to the latest unretracted version, run:
                 \tgo get {{{.PROVERB}}}@latest
-                go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
+                go: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 
                 """
             ComparisonOutput: """
 
                 \tgo get {{{.PROVERB}}}@latest
-                go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
                 go: downloading {{{.PROVERB}}} v1.0.1
                 go: to switch to the latest unretracted version, run:
+                go: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
                 go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
                 """
         }, {
@@ -9065,12 +9093,12 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.PROVERB}}} v0.4.0
-                go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
+                go: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 
                 """
             ComparisonOutput: """
 
-                go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
+                go: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
                 go: downloading {{{.PROVERB}}} v0.4.0
                 """
         }]
@@ -9196,7 +9224,7 @@ Steps: {
         }]
     }
 }
-Hash: "e8dd0d207479237a2ad5c4bae3807603adb72649141e4ff82a2a6c8b09ccade1"
+Hash: "a0e9b5de69b2e25ac50a27547ab7ddb8cf2fcacda227d67a8c7b205952a63c17"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -9204,7 +9232,7 @@ Delims: ["{{{", "}}}"]
 Defs: {
     mkcert:         "mkcert"
     mkcert_pkg:     "filippo.io/mkcert"
-    mkcert_version: "v1.4.2"
+    mkcert_version: "v1.4.4"
     pwg: {
         gopher_live: "gopher.live"
     }
@@ -9261,7 +9289,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go116: {
-                Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -9275,27 +9303,11 @@ Steps: {
         InformationOnly: false
         Terminal:        string
     }
-    go115_mkcert_get: {
-        DoNotTrim:       false
-        Name:            string
-        StepType:        1
-        Source:          "go get filippo.io/mkcert@v1.4.2"
-        InformationOnly: false
-        Terminal:        string
-    }
-    go115_mkcert_modules_get: {
-        DoNotTrim:       false
-        Name:            string
-        StepType:        1
-        Source:          "(cd $(mktemp -d); GO111MODULE=on go get filippo.io/mkcert@v1.4.2)"
-        InformationOnly: false
-        Terminal:        string
-    }
     go116_mkcert_install: {
         DoNotTrim:       false
         Name:            string
         StepType:        1
-        Source:          "go install filippo.io/mkcert@v1.4.2"
+        Source:          "go install filippo.io/mkcert@v1.4.4"
         InformationOnly: false
         Terminal:        string
     }
@@ -9330,7 +9342,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go116: {
-            Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -9353,58 +9365,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.16.15 linux/amd64"
-            ComparisonOutput: "go version go1.16.15 linux/amd64"
-        }]
-    }
-    go115_mkcert_get: {
-        StepType:        1
-        DoNotTrim:       false
-        InformationOnly: false
-        Name:            "go115_mkcert_get"
-        Order:           1
-        Terminal:        "term1"
-        Stmts: [{
-            Negated:  false
-            CmdStr:   "go get filippo.io/mkcert@v1.4.2"
-            ExitCode: 0
-            Output: """
-                go: downloading filippo.io/mkcert v1.4.2
-                go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-                go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
-                go: downloading honnef.co/go/tools v0.0.0-20191107024926-a9480a3ec3bc
-                go: downloading howett.net/plist v0.0.0-20181124034731-591f970eefbb
-                go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-                go: downloading golang.org/x/text v0.3.0
-                go: downloading github.com/BurntSushi/toml v0.3.1
-
-                """
-            ComparisonOutput: """
-
-                go: downloading filippo.io/mkcert v1.4.2
-                go: downloading github.com/BurntSushi/toml v0.3.1
-                go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-                go: downloading golang.org/x/text v0.3.0
-                go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
-                go: downloading honnef.co/go/tools v0.0.0-20191107024926-a9480a3ec3bc
-                go: downloading howett.net/plist v0.0.0-20181124034731-591f970eefbb
-                go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-                """
-        }]
-    }
-    go115_mkcert_modules_get: {
-        StepType:        1
-        DoNotTrim:       false
-        InformationOnly: false
-        Name:            "go115_mkcert_modules_get"
-        Order:           2
-        Terminal:        "term1"
-        Stmts: [{
-            Negated:          false
-            CmdStr:           "(cd $(mktemp -d); GO111MODULE=on go get filippo.io/mkcert@v1.4.2)"
-            ExitCode:         0
-            Output:           ""
-            ComparisonOutput: ""
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     go116_mkcert_install: {
@@ -9412,14 +9374,28 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "go116_mkcert_install"
-        Order:           3
+        Order:           1
         Terminal:        "term1"
         Stmts: [{
-            Negated:          false
-            CmdStr:           "go install filippo.io/mkcert@v1.4.2"
-            ExitCode:         0
-            Output:           ""
-            ComparisonOutput: ""
+            Negated:  false
+            CmdStr:   "go install filippo.io/mkcert@v1.4.4"
+            ExitCode: 0
+            Output: """
+                go: downloading filippo.io/mkcert v1.4.4
+                go: downloading golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+                go: downloading software.sslmate.com/src/go-pkcs12 v0.2.0
+                go: downloading golang.org/x/text v0.3.7
+                go: downloading golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
+
+                """
+            ComparisonOutput: """
+                go: downloading filippo.io/mkcert v1.4.4
+                go: downloading golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+                go: downloading software.sslmate.com/src/go-pkcs12 v0.2.0
+                go: downloading golang.org/x/text v0.3.7
+                go: downloading golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
+
+                """
         }]
     }
     which_mkcert: {
@@ -9427,7 +9403,7 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "which_mkcert"
-        Order:           4
+        Order:           2
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
@@ -9448,18 +9424,18 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "run_mkcert"
-        Order:           5
+        Order:           3
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
             CmdStr:   "mkcert -version"
             ExitCode: 0
             Output: """
-                v1.4.2
+                v1.4.4
 
                 """
             ComparisonOutput: """
-                v1.4.2
+                v1.4.4
 
                 """
         }]
@@ -9469,40 +9445,40 @@ Steps: {
         DoNotTrim:       false
         InformationOnly: false
         Name:            "goversion_mkcert"
-        Order:           6
+        Order:           4
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
             CmdStr:   "go version -m $(which mkcert)"
             ExitCode: 0
             Output: """
-                /home/gopher/go/bin/mkcert: go1.16.15
+                /home/gopher/go/bin/mkcert: go1.19.1
                 \tpath\tfilippo.io/mkcert
-                \tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
-                \tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-                \tdep\tgolang.org/x/text\tv0.3.0\th1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-                \tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.0.0-20180114231543-2291e8f0f237\th1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
-
+                \tmod\tfilippo.io/mkcert\tv1.4.4\th1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
+                \tdep\tgolang.org/x/crypto\tv0.0.0-20220331220935-ae2d96664a29\th1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+                \tdep\tgolang.org/x/net\tv0.0.0-20220421235706-1d1ef9303861\th1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+                \tdep\tgolang.org/x/text\tv0.3.7\th1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+                \tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.2.0\th1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
                 """
             ComparisonOutput: """
-                /home/gopher/go/bin/mkcert: go1.16.15
+                /home/gopher/go/bin/mkcert: go1.19.1
                 \tpath\tfilippo.io/mkcert
-                \tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
-                \tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-                \tdep\tgolang.org/x/text\tv0.3.0\th1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-                \tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.0.0-20180114231543-2291e8f0f237\th1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
-
+                \tmod\tfilippo.io/mkcert\tv1.4.4\th1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
+                \tdep\tgolang.org/x/crypto\tv0.0.0-20220331220935-ae2d96664a29\th1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+                \tdep\tgolang.org/x/net\tv0.0.0-20220421235706-1d1ef9303861\th1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+                \tdep\tgolang.org/x/text\tv0.3.7\th1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+                \tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.2.0\th1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
                 """
         }]
     }
 }
-Hash: "c82a16030f644b76c51e45f0ce0b71c14b3cf34798230d29b0c90526d8522d1c"
+Hash: "d19823b04cae5f5be42889ac3f5d71ed8700c12a3ac6e15c47c8cbd3fafef345"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
 Delims: ["{{{", "}}}"]
 Defs: {
-    staticcheck_version:      "v0.0.1-2020.1.6"
+    staticcheck_version:      "v0.3.3"
     staticcheck_conf:         "staticcheck.conf"
     staticcheck_st1000:       "ST1000"
     staticcheck_sa4018:       "SA4018"
@@ -9567,7 +9543,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -9585,7 +9561,7 @@ Steps: {
         DoNotTrim:       false
         Name:            string
         StepType:        1
-        Source:          "(cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)"
+        Source:          "go install honnef.co/go/tools/cmd/staticcheck@v0.3.3"
         InformationOnly: false
         Terminal:        string
     }
@@ -10281,7 +10257,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -10304,8 +10280,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     staticcheck_install: {
@@ -10317,23 +10293,25 @@ Steps: {
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
-            CmdStr:   "(cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)"
+            CmdStr:   "go install honnef.co/go/tools/cmd/staticcheck@v0.3.3"
             ExitCode: 0
             Output: """
-                go: downloading honnef.co/go/tools v0.0.1-2020.1.6
-                go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6
-                go: downloading golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef
-                go: downloading github.com/BurntSushi/toml v0.3.1
-                go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+                go: downloading honnef.co/go/tools v0.3.3
+                go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+                go: downloading golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
+                go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+                go: downloading github.com/BurntSushi/toml v0.4.1
+                go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 
                 """
             ComparisonOutput: """
+                go: downloading honnef.co/go/tools v0.3.3
+                go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+                go: downloading golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
+                go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+                go: downloading github.com/BurntSushi/toml v0.4.1
+                go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 
-                go: downloading github.com/BurntSushi/toml v0.3.1
-                go: downloading golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef
-                go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
-                go: downloading honnef.co/go/tools v0.0.1-2020.1.6
-                go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6
                 """
         }]
     }
@@ -10370,11 +10348,11 @@ Steps: {
             CmdStr:   "staticcheck -version"
             ExitCode: 0
             Output: """
-                staticcheck 2020.1.6
+                staticcheck 2022.1.3 (v0.3.3)
 
                 """
             ComparisonOutput: """
-                staticcheck 2020.1.6
+                staticcheck 2022.1.3 (v0.3.3)
 
                 """
         }]
@@ -10517,6 +10495,8 @@ Steps: {
                 Available since
                     2019.2
 
+                Online documentation
+                    https://staticcheck.io/docs/checks#SA5009
 
                 """
             ComparisonOutput: """
@@ -10525,6 +10505,8 @@ Steps: {
                 Available since
                     2019.2
 
+                Online documentation
+                    https://staticcheck.io/docs/checks#SA5009
 
                 """
         }]
@@ -11186,7 +11168,7 @@ Steps: {
         }]
     }
 }
-Hash: "66396cad683065b32470e992e2b449c499702986cff334556cdab46668d107d5"
+Hash: "29d51f4a617087a8662817a9ec8eae7670ad5825297397b2df912324ff2c1071"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -11264,7 +11246,7 @@ Defs: {
         branch:   "git branch"
         checkout: "git checkout"
     }
-    go_help_modprivate: "go help module-private"
+    go_help_modprivate: "go help module-auth"
     proxygolangorg: {
         waitforcache: "1m"
     }
@@ -11281,7 +11263,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -11514,7 +11496,7 @@ Steps: {
         DoNotTrim:       false
         Name:            string
         StepType:        1
-        Source:          "go help module-private"
+        Source:          "go help module-auth"
         InformationOnly: true
         Terminal:        string
     }
@@ -11634,8 +11616,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -11685,7 +11667,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -11708,8 +11690,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     public_init: {
@@ -12131,13 +12113,13 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
+                go: added {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
                 go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
                 """
         }]
     }
@@ -12175,7 +12157,7 @@ Steps: {
             CmdStr:   "go get {{{.PRIVATE}}}"
             ExitCode: 1
             Output: """
-                go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
+                go: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
                 \tserver response:
                 \tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
                 \t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
@@ -12190,7 +12172,7 @@ Steps: {
                 \tIf this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
                 \tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
                 \tserver response:
-                go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
+                go: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
                 """
         }]
     }
@@ -12222,7 +12204,7 @@ Steps: {
             ExitCode: 1
             Output: """
                 go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-                go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
+                go: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
                 \tserver response:
                 \tnot found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
                 \t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
@@ -12237,8 +12219,8 @@ Steps: {
                 \tIf this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
                 \tnot found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
                 \tserver response:
-                go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
                 go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+                go: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
                 """
         }]
     }
@@ -12251,94 +12233,28 @@ Steps: {
         Terminal:        "term1"
         Stmts: [{
             Negated:  false
-            CmdStr:   "go help module-private"
+            CmdStr:   "go help module-auth"
             ExitCode: 0
             Output: """
-                The go command defaults to downloading modules from the public Go module
-                mirror at proxy.golang.org. It also defaults to validating downloaded modules,
-                regardless of source, against the public Go checksum database at sum.golang.org.
-                These defaults work well for publicly available source code.
+                When the go command downloads a module zip file or go.mod file into the
+                module cache, it computes a cryptographic hash and compares it with a known
+                value to verify the file hasn't changed since it was first downloaded. Known
+                hashes are stored in a file in the module root directory named go.sum. Hashes
+                may also be downloaded from the checksum database depending on the values of
+                GOSUMDB, GOPRIVATE, and GONOSUMDB.
 
-                The GOPRIVATE environment variable controls which modules the go command
-                considers to be private (not available publicly) and should therefore not use the
-                proxy or checksum database. The variable is a comma-separated list of
-                glob patterns (in the syntax of Go's path.Match) of module path prefixes.
-                For example,
-
-                \tGOPRIVATE=*.corp.example.com,rsc.io/private
-
-                causes the go command to treat as private any module with a path prefix
-                matching either pattern, including git.corp.example.com/xyzzy, rsc.io/private,
-                and rsc.io/private/quux.
-
-                The GOPRIVATE environment variable may be used by other tools as well to
-                identify non-public modules. For example, an editor could use GOPRIVATE
-                to decide whether to hyperlink a package import to a godoc.org page.
-
-                For fine-grained control over module download and validation, the GONOPROXY
-                and GONOSUMDB environment variables accept the same kind of glob list
-                and override GOPRIVATE for the specific decision of whether to use the proxy
-                and checksum database, respectively.
-
-                For example, if a company ran a module proxy serving private modules,
-                users would configure go using:
-
-                \tGOPRIVATE=*.corp.example.com
-                \tGOPROXY=proxy.example.com
-                \tGONOPROXY=none
-
-                This would tell the go command and other tools that modules beginning with
-                a corp.example.com subdomain are private but that the company proxy should
-                be used for downloading both public and private modules, because
-                GONOPROXY has been set to a pattern that won't match any modules,
-                overriding GOPRIVATE.
-
-                The 'go env -w' command (see 'go help env') can be used to set these variables
-                for future go command invocations.
+                For details, see https://golang.org/ref/mod#authenticating.
 
                 """
             ComparisonOutput: """
-                The go command defaults to downloading modules from the public Go module
-                mirror at proxy.golang.org. It also defaults to validating downloaded modules,
-                regardless of source, against the public Go checksum database at sum.golang.org.
-                These defaults work well for publicly available source code.
+                When the go command downloads a module zip file or go.mod file into the
+                module cache, it computes a cryptographic hash and compares it with a known
+                value to verify the file hasn't changed since it was first downloaded. Known
+                hashes are stored in a file in the module root directory named go.sum. Hashes
+                may also be downloaded from the checksum database depending on the values of
+                GOSUMDB, GOPRIVATE, and GONOSUMDB.
 
-                The GOPRIVATE environment variable controls which modules the go command
-                considers to be private (not available publicly) and should therefore not use the
-                proxy or checksum database. The variable is a comma-separated list of
-                glob patterns (in the syntax of Go's path.Match) of module path prefixes.
-                For example,
-
-                \tGOPRIVATE=*.corp.example.com,rsc.io/private
-
-                causes the go command to treat as private any module with a path prefix
-                matching either pattern, including git.corp.example.com/xyzzy, rsc.io/private,
-                and rsc.io/private/quux.
-
-                The GOPRIVATE environment variable may be used by other tools as well to
-                identify non-public modules. For example, an editor could use GOPRIVATE
-                to decide whether to hyperlink a package import to a godoc.org page.
-
-                For fine-grained control over module download and validation, the GONOPROXY
-                and GONOSUMDB environment variables accept the same kind of glob list
-                and override GOPRIVATE for the specific decision of whether to use the proxy
-                and checksum database, respectively.
-
-                For example, if a company ran a module proxy serving private modules,
-                users would configure go using:
-
-                \tGOPRIVATE=*.corp.example.com
-                \tGOPROXY=proxy.example.com
-                \tGONOPROXY=none
-
-                This would tell the go command and other tools that modules beginning with
-                a corp.example.com subdomain are private but that the company proxy should
-                be used for downloading both public and private modules, because
-                GONOPROXY has been set to a pattern that won't match any modules,
-                overriding GOPRIVATE.
-
-                The 'go env -w' command (see 'go help env') can be used to set these variables
-                for future go command invocations.
+                For details, see https://golang.org/ref/mod#authenticating.
 
                 """
         }]
@@ -12371,13 +12287,13 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
+                go: added {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
                 go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-                go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
                 """
         }]
     }
@@ -12427,7 +12343,7 @@ Steps: {
         }]
     }
 }
-Hash: "5aeb0e6f8ca108e4c4267463519d57c906181a6c92b666c64fd9ad55336cfc6a"
+Hash: "f2232199872cd3dccfd7a2084716cd499551087f9944f36db3bb491eb2265caa"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -12520,7 +12436,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -12924,8 +12840,8 @@ Presteps: [{
             },
             {
               "Path": "github.com/play-with-go/preguide",
-              "Version": "v0.0.2-0.20220916045313-f81d11764005",
-              "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+              "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+              "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
               "Replace": null
             },
             {
@@ -12975,7 +12891,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -12998,8 +12914,8 @@ Steps: {
             Negated:          false
             CmdStr:           "go version"
             ExitCode:         0
-            Output:           "go version go1.15.15 linux/amd64"
-            ComparisonOutput: "go version go1.15.15 linux/amd64"
+            Output:           "go version go1.19.1 linux/amd64"
+            ComparisonOutput: "go version go1.19.1 linux/amd64"
         }]
     }
     branch_init: {
@@ -13567,10 +13483,12 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.BRANCH}}} v1.0.0
+                go: added {{{.BRANCH}}} v1.0.0
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.BRANCH}}} v1.0.0
                 go: downloading {{{.BRANCH}}} v1.0.0
                 """
         }, {
@@ -13579,10 +13497,12 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.BRANCH}}}/v2 v2.0.0
+                go: added {{{.BRANCH}}}/v2 v2.0.0
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.BRANCH}}}/v2 v2.0.0
                 go: downloading {{{.BRANCH}}}/v2 v2.0.0
                 """
         }, {
@@ -13591,10 +13511,12 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.SUBDIR}}} v1.0.0
+                go: added {{{.SUBDIR}}} v1.0.0
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.SUBDIR}}} v1.0.0
                 go: downloading {{{.SUBDIR}}} v1.0.0
                 """
         }, {
@@ -13603,10 +13525,12 @@ Steps: {
             ExitCode: 0
             Output: """
                 go: downloading {{{.SUBDIR}}}/v2 v2.0.0
+                go: added {{{.SUBDIR}}}/v2 v2.0.0
 
                 """
             ComparisonOutput: """
 
+                go: added {{{.SUBDIR}}}/v2 v2.0.0
                 go: downloading {{{.SUBDIR}}}/v2 v2.0.0
                 """
         }]
@@ -13639,7 +13563,7 @@ Steps: {
         }]
     }
 }
-Hash: "7dece9cb34390b221d2e98f2faa720ebb2fa859489ba010a8f63e3016d5121fb"
+Hash: "41c7f8744234fcd70be0eb280b0c4108d2f6b2cc6a46e7faccb6a8c9af7bba0a"
 Delims: ["{{{", "}}}"]
 // ---
 Networks: ["playwithgo_pwg"]
@@ -13684,7 +13608,7 @@ Terminals: {
         Description: "The main terminal"
         Scenarios: {
             go115: {
-                Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+                Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
             }
         }
     }
@@ -13695,7 +13619,7 @@ Terminals: [{
     Description: "The main terminal"
     Scenarios: {
         go115: {
-            Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+            Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
         }
     }
 }]
@@ -13744,7 +13668,7 @@ Steps: {
         }]
     }
 }
-Hash: "271f9cdbe52fe75c83acb8deecf95dc51ec068d641335bba20245003681ce10a"
+Hash: "09e26e2e121925fb298139537bf27cbb561802c097fd17a2c0d1be60fe318ffe"
 Delims: ["{{{", "}}}"]
 // ---
 import "strings"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/myitcv/docker-compose v0.0.0-20200623052903-c60483a3250f
 	github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e0
 	github.com/play-with-go/gitea v0.0.0-20220916095345-fddafa3403c2
-	github.com/play-with-go/preguide v0.0.2-0.20220916045313-f81d11764005
+	github.com/play-with-go/preguide v0.0.2-0.20220918055127-cc4d80fbbfa7
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -509,8 +509,8 @@ github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e
 github.com/play-with-docker/play-with-docker v0.0.3-0.20201025222131-e8486b8100e0/go.mod h1:fQEYtvon2ocbbFpyki/m+Bg2xqVS1YsRj1ylGnhmpm4=
 github.com/play-with-go/gitea v0.0.0-20220916095345-fddafa3403c2 h1:hNi/ACPKXTIEOV6hn0HfelzIqwkaLWQXKSElGCi8xKE=
 github.com/play-with-go/gitea v0.0.0-20220916095345-fddafa3403c2/go.mod h1:mfBUaCtcOXcYQ4GQRc5VbD2a2ia7gFme1pc+1qzwi6M=
-github.com/play-with-go/preguide v0.0.2-0.20220916045313-f81d11764005 h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=
-github.com/play-with-go/preguide v0.0.2-0.20220916045313-f81d11764005/go.mod h1:OiZEQ1+V6HA/Wh4koKxDn8EIFPWTpcylWyzKJ9CTIGY=
+github.com/play-with-go/preguide v0.0.2-0.20220918055127-cc4d80fbbfa7 h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=
+github.com/play-with-go/preguide v0.0.2-0.20220918055127-cc4d80fbbfa7/go.mod h1:OiZEQ1+V6HA/Wh4koKxDn8EIFPWTpcylWyzKJ9CTIGY=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/guide.cue
+++ b/guide.cue
@@ -10,14 +10,13 @@ Networks: *["playwithgo_pwg"] | [...string]
 
 Delims: ["{{{", "}}}"]
 
-_#dockerCommit: "c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+_#dockerCommit: ":5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 
-_#installGo:          "playwithgo/installgo1.15.15:\(_#dockerCommit)"
-_#go115LatestVersion: "go1.15.15"
-_#go115LatestImage:   "playwithgo/go1.15.15:\(_#dockerCommit)"
-_#go116LatestImage:   "playwithgo/go1.16.15:\(_#dockerCommit)"
+_#installGo:          "playwithgo/installgo1.19.1\(_#dockerCommit)"
+_#go119LatestVersion: "go1.19.1"
+_#go119LatestImage:   "playwithgo/go1.19.1\(_#dockerCommit)"
 
-_#golangToolsLatest: "v0.0.0-20201105220310-78b158585360"
+_#golangToolsLatest: "v0.1.13-0.20220917004541-4d18923f060e"
 
 _#StablePsuedoversionSuffix: "20060102150405-abcedf12345"
 

--- a/guides/2018-10-19-go-fundamentals/go115_en_log.txt
+++ b/guides/2018-10-19-go-fundamentals/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ pwd
 /home/gopher
 $ mkdir /home/gopher/greetings
@@ -9,7 +9,7 @@ go: creating new go.mod: module {{{.GREETINGS}}}
 $ cat go.mod
 module {{{.GREETINGS}}}
 
-go 1.15
+go 1.19
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 
@@ -51,7 +51,7 @@ $ go mod init {{{.HELLO}}}
 go: creating new go.mod: module {{{.HELLO}}}
 $ go get {{{.GREETINGS}}}
 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-go: {{{.GREETINGS}}} upgrade => v0.0.0-20060102150405-abcedf12345
+go: added {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
 $ go list -m -f {{.Version}} {{{.GREETINGS}}}
 v0.0.0-20060102150405-abcedf12345
 $ cat <<EOD > /home/gopher/hello/hello.go
@@ -107,8 +107,8 @@ remote: . Processing 1 references
 remote: Processed 1 references in total        
 $ cd /home/gopher/hello
 $ go get {{{.GREETINGS}}}@$greetings_error_commit
-go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 $ go list -m -f {{.Version}} {{{.GREETINGS}}}
 v0.0.0-20060102150405-abcedf12345
 $ cat <<EOD > /home/gopher/hello/hello.go
@@ -204,8 +204,8 @@ remote: . Processing 1 references
 remote: Processed 1 references in total        
 $ cd /home/gopher/hello
 $ go get {{{.GREETINGS}}}@$greetings_random_commit
-go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 $ go list -m -f {{.Version}} {{{.GREETINGS}}}
 v0.0.0-20060102150405-abcedf12345
 $ cat <<EOD > /home/gopher/hello/hello.go
@@ -315,9 +315,9 @@ $ go mod edit -replace {{{.GREETINGS}}}=/home/gopher/greetings
 $ cat go.mod
 module {{{.HELLO}}}
 
-go 1.15
+go 1.19
 
-require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 // indirect
 
 replace {{{.GREETINGS}}} => /home/gopher/greetings
 $ cat <<EOD > /home/gopher/hello/hello.go
@@ -385,14 +385,14 @@ func TestHelloEmpty(t *testing.T) {
 EOD
 $ go test
 PASS
-ok  	{{{.GREETINGS}}}	0.002s
+ok  	{{{.GREETINGS}}}	0.001s
 $ go test -v
 === RUN   TestHelloName
 --- PASS: TestHelloName (0.00s)
 === RUN   TestHelloEmpty
 --- PASS: TestHelloEmpty (0.00s)
 PASS
-ok  	{{{.GREETINGS}}}	0.002s
+ok  	{{{.GREETINGS}}}	0.001s
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 
@@ -465,7 +465,7 @@ $ go test
     greetings_test.go:15: Hello("Gladys") = "Hail, %v! Well met!", <nil>, want match for `\bGladys\b`, <nil>
 FAIL
 exit status 1
-FAIL	{{{.GREETINGS}}}	0.001s
+FAIL	{{{.GREETINGS}}}	0.002s
 $ cat <<EOD > /home/gopher/greetings/greetings.go
 package greetings
 
@@ -534,7 +534,7 @@ func randomFormat() string {
 EOD
 $ go test
 PASS
-ok  	{{{.GREETINGS}}}	0.001s
+ok  	{{{.GREETINGS}}}	0.002s
 $ cd /home/gopher/hello
 $ go list -f '{{.Target}}'
 /home/gopher/go/bin/hello

--- a/guides/2018-10-19-go-fundamentals/guide.cue
+++ b/guides/2018-10-19-go-fundamentals/guide.cue
@@ -37,7 +37,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {

--- a/guides/2018-10-19-go-fundamentals/out/gen_out.cue
+++ b/guides/2018-10-19-go-fundamentals/out/gen_out.cue
@@ -81,8 +81,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -132,7 +132,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -155,8 +155,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	pwd_home: {
@@ -236,13 +236,13 @@ Steps: {
 			Output: """
 				module {{{.GREETINGS}}}
 
-				go 1.15
+				go 1.19
 
 				"""
 			ComparisonOutput: """
 				module {{{.GREETINGS}}}
 
-				go 1.15
+				go 1.19
 
 				"""
 		}]
@@ -444,13 +444,13 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.GREETINGS}}} upgrade => v0.0.0-20060102150405-abcedf12345
+				go: added {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
 				go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.GREETINGS}}} upgrade => v0.0.0-20060102150405-abcedf12345
 				"""
 		}]
 	}
@@ -715,14 +715,14 @@ Steps: {
 			CmdStr:   "go get {{{.GREETINGS}}}@$greetings_error_commit"
 			ExitCode: 0
 			Output: """
-				go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 				go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+				go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
 				go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
+				go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 				"""
 		}]
 	}
@@ -1029,14 +1029,14 @@ Steps: {
 			CmdStr:   "go get {{{.GREETINGS}}}@$greetings_random_commit"
 			ExitCode: 0
 			Output: """
-				go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 				go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+				go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
 				go: downloading {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
+				go: upgraded {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 => v0.0.0-20060102150405-abcedf12345
 				"""
 		}]
 	}
@@ -1351,9 +1351,9 @@ Steps: {
 			Output: """
 				module {{{.HELLO}}}
 
-				go 1.15
+				go 1.19
 
-				require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+				require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 // indirect
 
 				replace {{{.GREETINGS}}} => /home/gopher/greetings
 
@@ -1361,9 +1361,9 @@ Steps: {
 			ComparisonOutput: """
 				module {{{.HELLO}}}
 
-				go 1.15
+				go 1.19
 
-				require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345
+				require {{{.GREETINGS}}} v0.0.0-20060102150405-abcedf12345 // indirect
 
 				replace {{{.GREETINGS}}} => /home/gopher/greetings
 
@@ -1532,7 +1532,7 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.002s
+				ok  \t{{{.GREETINGS}}}\t0.001s
 
 				"""
 			ComparisonOutput: """
@@ -1550,7 +1550,7 @@ Steps: {
 				=== RUN   TestHelloEmpty
 				--- PASS: TestHelloEmpty (0.00s)
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.002s
+				ok  \t{{{.GREETINGS}}}\t0.001s
 
 				"""
 			ComparisonOutput: """
@@ -1724,7 +1724,7 @@ Steps: {
 				    greetings_test.go:15: Hello("Gladys") = "Hail, %v! Well met!", <nil>, want match for `\\bGladys\\b`, <nil>
 				FAIL
 				exit status 1
-				FAIL\t{{{.GREETINGS}}}\t0.001s
+				FAIL\t{{{.GREETINGS}}}\t0.002s
 
 				"""
 			ComparisonOutput: """
@@ -1894,7 +1894,7 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				PASS
-				ok  \t{{{.GREETINGS}}}\t0.001s
+				ok  \t{{{.GREETINGS}}}\t0.002s
 
 				"""
 			ComparisonOutput: """
@@ -1998,5 +1998,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "4030ef2161a08fd4057fffd4499e5b683247d45a04169c7cf11892d42c9f2138"
+Hash: "5eaa4bac4c0d61559e4ada00c264ad04e45e2b4635a313f9596008eef77a880e"
 Delims: ["{{{", "}}}"]

--- a/guides/2019-10-15-get-started-with-go/go115_en_log.txt
+++ b/guides/2019-10-15-get-started-with-go/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ pwd
 /home/gopher
 $ mkdir /home/gopher/hello
@@ -30,9 +30,14 @@ func main() {
 EOD
 $ go mod init hello
 go: creating new go.mod: module hello
+go: to add module requirements and sums:
+	go mod tidy
 $ go get rsc.io/quote@v1.5.2
 go: downloading rsc.io/quote v1.5.2
 go: downloading rsc.io/sampler v1.3.0
 go: downloading golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+go: added golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+go: added rsc.io/quote v1.5.2
+go: added rsc.io/sampler v1.3.0
 $ go run hello.go
 Don't communicate by sharing memory, share memory by communicating.

--- a/guides/2019-10-15-get-started-with-go/guide.cue
+++ b/guides/2019-10-15-get-started-with-go/guide.cue
@@ -19,7 +19,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {

--- a/guides/2019-10-15-get-started-with-go/out/gen_out.cue
+++ b/guides/2019-10-15-get-started-with-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -28,8 +28,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	pwd_home: {
@@ -162,10 +162,14 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: creating new go.mod: module hello
+				go: to add module requirements and sums:
+				\tgo mod tidy
 
 				"""
 			ComparisonOutput: """
 				go: creating new go.mod: module hello
+				go: to add module requirements and sums:
+				\tgo mod tidy
 
 				"""
 		}]
@@ -185,10 +189,16 @@ Steps: {
 				go: downloading rsc.io/quote v1.5.2
 				go: downloading rsc.io/sampler v1.3.0
 				go: downloading golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+				go: added golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+				go: added rsc.io/quote v1.5.2
+				go: added rsc.io/sampler v1.3.0
 
 				"""
 			ComparisonOutput: """
 
+				go: added golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+				go: added rsc.io/quote v1.5.2
+				go: added rsc.io/sampler v1.3.0
 				go: downloading golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
 				go: downloading rsc.io/quote v1.5.2
 				go: downloading rsc.io/sampler v1.3.0
@@ -217,5 +227,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "13b62f3b7d87bd98ecc52b27beabea85d4a954d86f0a1ff3ac75aed4b213b07f"
+Hash: "5deda7db40f740e3769be5cc2e7ac9dff1bb782bf714e5011e9f5d84abab8774"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-08-13-installing-go/go115_en_log.txt
+++ b/guides/2020-08-13-installing-go/go115_en_log.txt
@@ -1,11 +1,11 @@
 $ pwd
 /home/gopher
-$ wget -q https://golang.org/dl/go1.15.15.linux-$GOARCH.tar.gz
-$ sudo tar -C /usr/local -xzf go1.15.15.linux-$GOARCH.tar.gz
+$ wget -q https://golang.org/dl/go1.19.1.linux-$GOARCH.tar.gz
+$ sudo tar -C /usr/local -xzf go1.19.1.linux-$GOARCH.tar.gz
 $ echo export PATH="/usr/local/go/bin:$PATH" >>$HOME/.profile
 $ source $HOME/.profile
 $ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ go env
 GO111MODULE=""
 GOARCH="amd64"
@@ -13,6 +13,7 @@ GOBIN=""
 GOCACHE="/home/gopher/.cache/go-build"
 GOENV="/home/gopher/.config/go/env"
 GOEXE=""
+GOEXPERIMENT=""
 GOFLAGS=""
 GOHOSTARCH="amd64"
 GOHOSTOS="linux"
@@ -28,19 +29,21 @@ GOROOT="/usr/local/go"
 GOSUMDB="sum.golang.org"
 GOTMPDIR=""
 GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
+GOVCS=""
+GOVERSION="go1.19.1"
 GCCGO="gccgo"
 AR="ar"
 CC="gcc"
 CXX="g++"
 CGO_ENABLED="1"
-GOMOD=""
+GOMOD="/dev/null"
+GOWORK=""
 CGO_CFLAGS="-g -O2"
 CGO_CPPFLAGS=""
 CGO_CXXFLAGS="-g -O2"
 CGO_FFLAGS="-g -O2"
 CGO_LDFLAGS="-g -O2"
 PKG_CONFIG="pkg-config"
-GOGCCFLAGS="fake_gcc_flags"
 $ go env GOBIN
 
 $ go env -w GOBIN=/path/to/my/gobin

--- a/guides/2020-08-13-installing-go/guide.cue
+++ b/guides/2020-08-13-installing-go/guide.cue
@@ -27,13 +27,13 @@ Steps: start_dir: preguide.#Command & {
 
 Steps: download_go: preguide.#Command & {
 	Source: """
-		wget -q https://golang.org/dl/\(_#go115LatestVersion).linux-$GOARCH.tar.gz
+		wget -q https://golang.org/dl/\(_#go119LatestVersion).linux-$GOARCH.tar.gz
 		"""
 }
 
 Steps: install_go: preguide.#Command & {
 	Source: """
-		sudo tar -C /usr/local -xzf \(_#go115LatestVersion).linux-$GOARCH.tar.gz
+		sudo tar -C /usr/local -xzf \(_#go119LatestVersion).linux-$GOARCH.tar.gz
 		"""
 }
 

--- a/guides/2020-08-13-installing-go/out/gen_out.cue
+++ b/guides/2020-08-13-installing-go/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/installgo1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/installgo1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -47,7 +47,7 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
-			CmdStr:           "wget -q https://golang.org/dl/go1.15.15.linux-$GOARCH.tar.gz"
+			CmdStr:           "wget -q https://golang.org/dl/go1.19.1.linux-$GOARCH.tar.gz"
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
@@ -62,7 +62,7 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:          false
-			CmdStr:           "sudo tar -C /usr/local -xzf go1.15.15.linux-$GOARCH.tar.gz"
+			CmdStr:           "sudo tar -C /usr/local -xzf go1.19.1.linux-$GOARCH.tar.gz"
 			ExitCode:         0
 			Output:           ""
 			ComparisonOutput: ""
@@ -109,8 +109,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	go_env: {
@@ -131,6 +131,7 @@ Steps: {
 				GOCACHE="/home/gopher/.cache/go-build"
 				GOENV="/home/gopher/.config/go/env"
 				GOEXE=""
+				GOEXPERIMENT=""
 				GOFLAGS=""
 				GOHOSTARCH="amd64"
 				GOHOSTOS="linux"
@@ -146,19 +147,21 @@ Steps: {
 				GOSUMDB="sum.golang.org"
 				GOTMPDIR=""
 				GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
+				GOVCS=""
+				GOVERSION="go1.19.1"
 				GCCGO="gccgo"
 				AR="ar"
 				CC="gcc"
 				CXX="g++"
 				CGO_ENABLED="1"
-				GOMOD=""
+				GOMOD="/dev/null"
+				GOWORK=""
 				CGO_CFLAGS="-g -O2"
 				CGO_CPPFLAGS=""
 				CGO_CXXFLAGS="-g -O2"
 				CGO_FFLAGS="-g -O2"
 				CGO_LDFLAGS="-g -O2"
 				PKG_CONFIG="pkg-config"
-				GOGCCFLAGS="fake_gcc_flags"
 
 				"""
 			ComparisonOutput: """
@@ -168,6 +171,7 @@ Steps: {
 				GOCACHE="/home/gopher/.cache/go-build"
 				GOENV="/home/gopher/.config/go/env"
 				GOEXE=""
+				GOEXPERIMENT=""
 				GOFLAGS=""
 				GOHOSTARCH="amd64"
 				GOHOSTOS="linux"
@@ -183,19 +187,21 @@ Steps: {
 				GOSUMDB="sum.golang.org"
 				GOTMPDIR=""
 				GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
+				GOVCS=""
+				GOVERSION="go1.19.1"
 				GCCGO="gccgo"
 				AR="ar"
 				CC="gcc"
 				CXX="g++"
 				CGO_ENABLED="1"
-				GOMOD=""
+				GOMOD="/dev/null"
+				GOWORK=""
 				CGO_CFLAGS="-g -O2"
 				CGO_CPPFLAGS=""
 				CGO_CXXFLAGS="-g -O2"
 				CGO_FFLAGS="-g -O2"
 				CGO_LDFLAGS="-g -O2"
 				PKG_CONFIG="pkg-config"
-				GOGCCFLAGS="fake_gcc_flags"
 
 				"""
 		}]
@@ -448,5 +454,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "57f9241df49785e337140bd0aa692834aac59089f3b266546b0f3ac12cc7cddc"
+Hash: "6823ef57ddaff8214fd4ab7366db217f74bd29901bda3d8ba0c6b8a283732e24"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-09-01-basic-go-modules-example/go115_en_log.txt
+++ b/guides/2020-09-01-basic-go-modules-example/go115_en_log.txt
@@ -29,7 +29,7 @@ $ go mod init mod.com
 go: creating new go.mod: module mod.com
 $ go get {{{.REPO1}}}
 go: downloading {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
-go: {{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcedf12345
+go: added {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
 $ go run {{{.REPO1}}}
 Hello, world!
 $ go list -m -f {{.Version}} {{{.REPO1}}}

--- a/guides/2020-09-01-basic-go-modules-example/guide.cue
+++ b/guides/2020-09-01-basic-go-modules-example/guide.cue
@@ -28,7 +28,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: create_module: preguide.#Command & {

--- a/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
+++ b/guides/2020-09-01-basic-go-modules-example/out/gen_out.cue
@@ -77,8 +77,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -128,7 +128,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -305,13 +305,13 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcedf12345
+				go: added {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
 				go: downloading {{{.REPO1}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.REPO1}}} upgrade => v0.0.0-20060102150405-abcedf12345
 				"""
 		}, {
 			Negated:  false
@@ -350,5 +350,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "703d7b8f9690e147301b8824a58f1fcaadf55bc2cad6ae498ef6ef33db2bf706"
+Hash: "ae3238b78d035abf6fc957d0c603b0506d75a724b225fcfacb127ba4e8f7b810"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-10-07-intro-to-play-with-go-dev/guide.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/guide.cue
@@ -30,7 +30,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: whoami: preguide.#Command & {

--- a/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
+++ b/guides/2020-10-07-intro-to-play-with-go-dev/out/gen_out.cue
@@ -77,8 +77,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -128,7 +128,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -354,5 +354,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "b53dcd3de8b90157ae825182f021b1c7087125438c18e54e2bc618d1e214588a"
+Hash: "772eb554083abcd286edfc7be26d16d0bfefcf7a6740ab3342b60e2609d1e744"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
+++ b/guides/2020-11-05-tools-as-dependencies/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ mkdir painkiller
 $ cd painkiller
 $ go mod init painkiller
@@ -80,17 +80,23 @@ import (
 )
 
 EOD
-$ go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-go: downloading golang.org/x/mod v0.3.0
-go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+$ go get golang.org/x/tools/cmd/stringer@v0.1.13-0.20220917004541-4d18923f060e
+go: downloading golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
+go: downloading golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+go: added golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+go: added golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+go: added golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
 $ cat go.mod
 module painkiller
 
-go 1.15
+go 1.19
 
-require golang.org/x/tools v0.0.0-20201105220310-78b158585360 // indirect
+require (
+	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e // indirect
+)
 $ go mod tidy
 $ go run golang.org/x/tools/cmd/stringer -help
 Usage of stringer:

--- a/guides/2020-11-05-tools-as-dependencies/guide.cue
+++ b/guides/2020-11-05-tools-as-dependencies/guide.cue
@@ -34,7 +34,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {

--- a/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
+++ b/guides/2020-11-05-tools-as-dependencies/out/gen_out.cue
@@ -77,8 +77,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -128,7 +128,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -151,8 +151,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	painkiller_go_mod_init: {
@@ -400,21 +400,25 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
-			CmdStr:   "go get golang.org/x/tools/cmd/stringer@v0.0.0-20201105220310-78b158585360"
+			CmdStr:   "go get golang.org/x/tools/cmd/stringer@v0.1.13-0.20220917004541-4d18923f060e"
 			ExitCode: 0
 			Output: """
-				go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
-				go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
-				go: downloading golang.org/x/mod v0.3.0
-				go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+				go: downloading golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
+				go: downloading golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+				go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+				go: added golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+				go: added golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+				go: added golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
 
 				"""
 			ComparisonOutput: """
 
-				go: downloading golang.org/x/mod v0.3.0
-				go: downloading golang.org/x/tools v0.0.0-20201105220310-78b158585360
-				go: downloading golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
-				go: found golang.org/x/tools/cmd/stringer in golang.org/x/tools v0.0.0-20201105220310-78b158585360
+				go: added golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+				go: added golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+				go: added golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
+				go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
+				go: downloading golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
+				go: downloading golang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e
 				"""
 		}]
 	}
@@ -432,17 +436,25 @@ Steps: {
 			Output: """
 				module painkiller
 
-				go 1.15
+				go 1.19
 
-				require golang.org/x/tools v0.0.0-20201105220310-78b158585360 // indirect
+				require (
+				\tgolang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+				\tgolang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+				\tgolang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e // indirect
+				)
 
 				"""
 			ComparisonOutput: """
 				module painkiller
 
-				go 1.15
+				go 1.19
 
-				require golang.org/x/tools v0.0.0-20201105220310-78b158585360 // indirect
+				require (
+				\tgolang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
+				\tgolang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+				\tgolang.org/x/tools v0.1.13-0.20220917004541-4d18923f060e // indirect
+				)
 
 				"""
 		}]
@@ -789,5 +801,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "422eaf5b740efdf4c0016fabc28e2438e057a7108260db3be9edd4787ca4a0ca"
+Hash: "f440fa815f06042623db1e5dcbc6fb91863ff214da8db577281584cb87006d59"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-08-retract-module-versions/go116_en_log.txt
+++ b/guides/2020-11-08-retract-module-versions/go116_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.16.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ mkdir /home/gopher/proverb
 $ cd /home/gopher/proverb
 $ git init -q
@@ -45,7 +45,7 @@ func main() {
 EOD
 $ go get {{{.PROVERB}}}@v0.1.0
 go: downloading {{{.PROVERB}}} v0.1.0
-go get: added {{{.PROVERB}}} v0.1.0
+go: added {{{.PROVERB}}} v0.1.0
 $ go run .
 Don't communicate by sharing memory, share memory by communicating.
 $ cd /home/gopher/proverb
@@ -71,7 +71,7 @@ remote: Processed 1 references in total
 $ cd /home/gopher/gopher
 $ go get {{{.PROVERB}}}@v0.2.0
 go: downloading {{{.PROVERB}}} v0.2.0
-go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
+go: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 $ go run .
 Concurrency is parallelism.
 $ cd /home/gopher/proverb
@@ -79,7 +79,7 @@ $ go mod edit -retract=v0.2.0
 $ cat go.mod
 module {{{.PROVERB}}}
 
-go 1.16
+go 1.19
 
 retract v0.2.0
 $ cat <<EOD > /home/gopher/proverb/go.mod
@@ -113,7 +113,7 @@ $ [ "$(git status --porcelain)" == "" ] || (git status && false)
 $ cd /home/gopher/gopher
 $ go get {{{.PROVERB}}}@v0.3.0
 go: downloading {{{.PROVERB}}} v0.3.0
-go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 $ go run .
 Concurrency is not parallelism.
 $ sleep 1m
@@ -125,14 +125,14 @@ $ go get {{{.PROVERB}}}@v0.2.0
 go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 go: to switch to the latest unretracted version, run:
 	go get {{{.PROVERB}}}@latest
-go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+go: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 $ go run .
 Concurrency is parallelism.
 $ go list -m -u all
 gopher
 {{{.PROVERB}}} v0.2.0 (retracted) [v0.3.0]
 $ go get {{{.PROVERB}}}@latest
-go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 $ cd /home/gopher/proverb
 $ cat <<EOD > /home/gopher/proverb/proverb.go
 package proverb
@@ -193,16 +193,16 @@ go: downloading {{{.PROVERB}}} v1.0.0
 go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 go: to switch to the latest unretracted version, run:
 	go get {{{.PROVERB}}}@latest
-go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
+go: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 $ go get {{{.PROVERB}}}@v1.0.1
 go: downloading {{{.PROVERB}}} v1.0.1
 go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 go: to switch to the latest unretracted version, run:
 	go get {{{.PROVERB}}}@latest
-go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
+go: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 $ go get {{{.PROVERB}}}@v0.4.0
 go: downloading {{{.PROVERB}}} v0.4.0
-go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
+go: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 $ sleep 1m
 $ go list -m -versions -retracted {{{.PROVERB}}}
 {{{.PROVERB}}} v0.1.0 v0.2.0 v0.3.0 v0.4.0 v1.0.0 v1.0.1

--- a/guides/2020-11-08-retract-module-versions/guide.cue
+++ b/guides/2020-11-08-retract-module-versions/guide.cue
@@ -39,7 +39,7 @@ Scenarios: go116: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go116: Image: _#go116LatestImage
+	Scenarios: go116: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {

--- a/guides/2020-11-08-retract-module-versions/out/gen_out.cue
+++ b/guides/2020-11-08-retract-module-versions/out/gen_out.cue
@@ -77,8 +77,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -128,7 +128,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -151,8 +151,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.16.15 linux/amd64"
-			ComparisonOutput: "go version go1.16.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	proverb_create: {
@@ -370,12 +370,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.1.0
-				go get: added {{{.PROVERB}}} v0.1.0
+				go: added {{{.PROVERB}}} v0.1.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: added {{{.PROVERB}}} v0.1.0
+				go: added {{{.PROVERB}}} v0.1.0
 				go: downloading {{{.PROVERB}}} v0.1.0
 				"""
 		}]
@@ -543,13 +543,13 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.2.0
-				go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
+				go: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 				go: downloading {{{.PROVERB}}} v0.2.0
+				go: upgraded {{{.PROVERB}}} v0.1.0 => v0.2.0
 				"""
 		}, {
 			Negated:  false
@@ -609,7 +609,7 @@ Steps: {
 			Output: """
 				module {{{.PROVERB}}}
 
-				go 1.16
+				go 1.19
 
 				retract v0.2.0
 
@@ -617,7 +617,7 @@ Steps: {
 			ComparisonOutput: """
 				module {{{.PROVERB}}}
 
-				go 1.16
+				go 1.19
 
 				retract v0.2.0
 
@@ -762,13 +762,13 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.3.0
-				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+				go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 				go: downloading {{{.PROVERB}}} v0.3.0
+				go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 				"""
 		}]
 	}
@@ -865,13 +865,13 @@ Steps: {
 				go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 				go: to switch to the latest unretracted version, run:
 				\tgo get {{{.PROVERB}}}@latest
-				go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+				go: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 
 				"""
 			ComparisonOutput: """
 
 				\tgo get {{{.PROVERB}}}@latest
-				go get: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
+				go: downgraded {{{.PROVERB}}} v0.3.0 => v0.2.0
 				go: to switch to the latest unretracted version, run:
 				go: warning: {{{.PROVERB}}}@v0.2.0: retracted by module author: Go proverb was totally wrong
 				"""
@@ -933,12 +933,12 @@ Steps: {
 			CmdStr:   "go get {{{.PROVERB}}}@latest"
 			ExitCode: 0
 			Output: """
-				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+				go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
+				go: upgraded {{{.PROVERB}}} v0.2.0 => v0.3.0
 				"""
 		}]
 	}
@@ -1249,15 +1249,15 @@ Steps: {
 				go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 				go: to switch to the latest unretracted version, run:
 				\tgo get {{{.PROVERB}}}@latest
-				go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
+				go: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 
 				"""
 			ComparisonOutput: """
 
 				\tgo get {{{.PROVERB}}}@latest
-				go get: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 				go: downloading {{{.PROVERB}}} v1.0.0
 				go: to switch to the latest unretracted version, run:
+				go: upgraded {{{.PROVERB}}} v0.3.0 => v1.0.0
 				go: warning: {{{.PROVERB}}}@v1.0.0: retracted by module author: Published v1 too early
 				"""
 		}, {
@@ -1269,15 +1269,15 @@ Steps: {
 				go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 				go: to switch to the latest unretracted version, run:
 				\tgo get {{{.PROVERB}}}@latest
-				go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
+				go: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 
 				"""
 			ComparisonOutput: """
 
 				\tgo get {{{.PROVERB}}}@latest
-				go get: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 				go: downloading {{{.PROVERB}}} v1.0.1
 				go: to switch to the latest unretracted version, run:
+				go: upgraded {{{.PROVERB}}} v1.0.0 => v1.0.1
 				go: warning: {{{.PROVERB}}}@v1.0.1: retracted by module author: Published v1 too early
 				"""
 		}, {
@@ -1286,12 +1286,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PROVERB}}} v0.4.0
-				go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
+				go: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 
 				"""
 			ComparisonOutput: """
 
-				go get: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
+				go: downgraded {{{.PROVERB}}} v1.0.1 => v0.4.0
 				go: downloading {{{.PROVERB}}} v0.4.0
 				"""
 		}]
@@ -1417,5 +1417,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "e8dd0d207479237a2ad5c4bae3807603adb72649141e4ff82a2a6c8b09ccade1"
+Hash: "a0e9b5de69b2e25ac50a27547ab7ddb8cf2fcacda227d67a8c7b205952a63c17"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-installing-go-programs-directly/en.markdown
+++ b/guides/2020-11-09-installing-go-programs-directly/en.markdown
@@ -12,7 +12,7 @@ and tool author._
 Users need a simple, easy-to-remember way to install Go programs. Similarly, tool authors need a short one-liner they
 can include at the top of their `README.md` explaining how to install the tool.
 
-Go 1.16 introduces a new way to install Go programs directly with the `go` command. This guide
+Go 1.16 introduced a new way to install Go programs directly with the `go` command. This guide
 introduces the new mode of `{{{ .cmdgo.install }}}` using the example of
 [`{{{ .mkcert_pkg }}}`](https://{{{ .mkcert_pkg }}}), and is suitable for both end users and tool authors.
 
@@ -26,42 +26,10 @@ This guide is running with:
 
 {{{ step "goversion" }}}
 
-### Background
-
-Currently, tool authors who want to provide installation instructions in their projects' `README.md` typically include:
-
-{{{ step "go115_mkcert_get" }}}
-
-_Note: most `README.md` instructions that use `{{{ .cmdgo.get }}}` do not specify a version. This results in the latest
-version of a package being fetched. A specific version, `{{{.mkcert_version}}}`, is used here to ensure this guide
-remains reproducible._
-
-There are a number of problems with this approach:
-
-* A user might run the above `{{{ .cmdgo.get }}}` within a module, which would
-  update the current module's dependencies, rather than just installing the tool directly.
-* `{{{ .cmdgo.get }}}` might not be running in module mode at all, for example
-  if the user previously modified `{{{ .cmdgo.GO111MODULE }}}`.
-* The use of `{{{ .cmdgo.get }}}` is confusing; it is used to download and install executables,
-  but it's also responsible for managing dependencies in `go.mod` files.
-
-Prior to Go 1.16, the general advice to fix the first two problems was to use a snippet
-which runs `{{{ .cmdgo.get }}}` in module mode and outside any module, by using a temporary directory:
-
-{{{ step "go115_mkcert_modules_get" }}}
-
-However, this new approach had its own problems:
-
-* It's not user-friendly; the extra shell is confusing to newcomers, and hard to remember.
-* It's not cross platform; the command is not guaranteed to work on Windows.
-
-It is clear that neither method is satisfactory, especially for `README.md`
-instructions which are meant to be brief and easy to follow.
-
 ### `{{{ .cmdgo.install }}}` in Go 1.16
 
-In Go 1.16, the `{{{ .cmdgo.install }}}` command is now used to install programs directly, i.e. regardless of the current
-module context:
+As of Go 1.16, the `{{{ .cmdgo.install }}}` command is now used to install
+programs directly, i.e. regardless of the current module context:
 
 {{{ step "go116_mkcert_install" }}}
 
@@ -89,7 +57,7 @@ install programs is being deprecated in Go 1.16.
 
 ### Conclusion
 
-That's it! Time to sit back and wait for the release of Go 1.16!
+That's it!
 
 As a next step you might like to consider:
 

--- a/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
+++ b/guides/2020-11-09-installing-go-programs-directly/go116_en_log.txt
@@ -1,24 +1,20 @@
 $ go version
-go version go1.16.15 linux/amd64
-$ go get filippo.io/mkcert@v1.4.2
-go: downloading filippo.io/mkcert v1.4.2
-go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
-go: downloading honnef.co/go/tools v0.0.0-20191107024926-a9480a3ec3bc
-go: downloading howett.net/plist v0.0.0-20181124034731-591f970eefbb
-go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-go: downloading golang.org/x/text v0.3.0
-go: downloading github.com/BurntSushi/toml v0.3.1
-$ (cd $(mktemp -d); GO111MODULE=on go get filippo.io/mkcert@v1.4.2)
-$ go install filippo.io/mkcert@v1.4.2
+go version go1.19.1 linux/amd64
+$ go install filippo.io/mkcert@v1.4.4
+go: downloading filippo.io/mkcert v1.4.4
+go: downloading golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+go: downloading software.sslmate.com/src/go-pkcs12 v0.2.0
+go: downloading golang.org/x/text v0.3.7
+go: downloading golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
 $ which mkcert
 /home/gopher/go/bin/mkcert
 $ mkcert -version
-v1.4.2
+v1.4.4
 $ go version -m $(which mkcert)
-/home/gopher/go/bin/mkcert: go1.16.15
+/home/gopher/go/bin/mkcert: go1.19.1
 	path	filippo.io/mkcert
-	mod	filippo.io/mkcert	v1.4.2	h1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
-	dep	golang.org/x/net	v0.0.0-20190620200207-3b0461eec859	h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-	dep	golang.org/x/text	v0.3.0	h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-	dep	software.sslmate.com/src/go-pkcs12	v0.0.0-20180114231543-2291e8f0f237	h1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
+	mod	filippo.io/mkcert	v1.4.4	h1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
+	dep	golang.org/x/crypto	v0.0.0-20220331220935-ae2d96664a29	h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+	dep	golang.org/x/net	v0.0.0-20220421235706-1d1ef9303861	h1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+	dep	golang.org/x/text	v0.3.7	h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+	dep	software.sslmate.com/src/go-pkcs12	v0.2.0	h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=

--- a/guides/2020-11-09-installing-go-programs-directly/guide.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/guide.cue
@@ -8,7 +8,7 @@ Defs: {
 	_#commonDefs
 	mkcert:         "mkcert"
 	mkcert_pkg:     "filippo.io/mkcert"
-	mkcert_version: "v1.4.2"
+	mkcert_version: "v1.4.4"
 	mktemp:         "mktemp -d"
 }
 
@@ -18,24 +18,12 @@ Scenarios: go116: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go116: Image: _#go116LatestImage
+	Scenarios: go116: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {
 	Source: """
 		go version
-		"""
-}
-
-Steps: go115_mkcert_get: preguide.#Command & {
-	Source: """
-		go get \(Defs.mkcert_pkg)@\(Defs.mkcert_version)
-		"""
-}
-
-Steps: go115_mkcert_modules_get: preguide.#Command & {
-	Source: """
-		(cd $(\(Defs.mktemp)); GO111MODULE=on go get \(Defs.mkcert_pkg)@\(Defs.mkcert_version))
 		"""
 }
 

--- a/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
+++ b/guides/2020-11-09-installing-go-programs-directly/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go116: {
-			Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -28,58 +28,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.16.15 linux/amd64"
-			ComparisonOutput: "go version go1.16.15 linux/amd64"
-		}]
-	}
-	go115_mkcert_get: {
-		StepType:        1
-		DoNotTrim:       false
-		InformationOnly: false
-		Name:            "go115_mkcert_get"
-		Order:           1
-		Terminal:        "term1"
-		Stmts: [{
-			Negated:  false
-			CmdStr:   "go get filippo.io/mkcert@v1.4.2"
-			ExitCode: 0
-			Output: """
-				go: downloading filippo.io/mkcert v1.4.2
-				go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-				go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
-				go: downloading honnef.co/go/tools v0.0.0-20191107024926-a9480a3ec3bc
-				go: downloading howett.net/plist v0.0.0-20181124034731-591f970eefbb
-				go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-				go: downloading golang.org/x/text v0.3.0
-				go: downloading github.com/BurntSushi/toml v0.3.1
-
-				"""
-			ComparisonOutput: """
-
-				go: downloading filippo.io/mkcert v1.4.2
-				go: downloading github.com/BurntSushi/toml v0.3.1
-				go: downloading golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-				go: downloading golang.org/x/text v0.3.0
-				go: downloading golang.org/x/tools v0.0.0-20191108193012-7d206e10da11
-				go: downloading honnef.co/go/tools v0.0.0-20191107024926-a9480a3ec3bc
-				go: downloading howett.net/plist v0.0.0-20181124034731-591f970eefbb
-				go: downloading software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
-				"""
-		}]
-	}
-	go115_mkcert_modules_get: {
-		StepType:        1
-		DoNotTrim:       false
-		InformationOnly: false
-		Name:            "go115_mkcert_modules_get"
-		Order:           2
-		Terminal:        "term1"
-		Stmts: [{
-			Negated:          false
-			CmdStr:           "(cd $(mktemp -d); GO111MODULE=on go get filippo.io/mkcert@v1.4.2)"
-			ExitCode:         0
-			Output:           ""
-			ComparisonOutput: ""
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	go116_mkcert_install: {
@@ -87,14 +37,28 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "go116_mkcert_install"
-		Order:           3
+		Order:           1
 		Terminal:        "term1"
 		Stmts: [{
-			Negated:          false
-			CmdStr:           "go install filippo.io/mkcert@v1.4.2"
-			ExitCode:         0
-			Output:           ""
-			ComparisonOutput: ""
+			Negated:  false
+			CmdStr:   "go install filippo.io/mkcert@v1.4.4"
+			ExitCode: 0
+			Output: """
+				go: downloading filippo.io/mkcert v1.4.4
+				go: downloading golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+				go: downloading software.sslmate.com/src/go-pkcs12 v0.2.0
+				go: downloading golang.org/x/text v0.3.7
+				go: downloading golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
+
+				"""
+			ComparisonOutput: """
+				go: downloading filippo.io/mkcert v1.4.4
+				go: downloading golang.org/x/net v0.0.0-20220421235706-1d1ef9303861
+				go: downloading software.sslmate.com/src/go-pkcs12 v0.2.0
+				go: downloading golang.org/x/text v0.3.7
+				go: downloading golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
+
+				"""
 		}]
 	}
 	which_mkcert: {
@@ -102,7 +66,7 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "which_mkcert"
-		Order:           4
+		Order:           2
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
@@ -123,18 +87,18 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "run_mkcert"
-		Order:           5
+		Order:           3
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
 			CmdStr:   "mkcert -version"
 			ExitCode: 0
 			Output: """
-				v1.4.2
+				v1.4.4
 
 				"""
 			ComparisonOutput: """
-				v1.4.2
+				v1.4.4
 
 				"""
 		}]
@@ -144,32 +108,32 @@ Steps: {
 		DoNotTrim:       false
 		InformationOnly: false
 		Name:            "goversion_mkcert"
-		Order:           6
+		Order:           4
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
 			CmdStr:   "go version -m $(which mkcert)"
 			ExitCode: 0
 			Output: """
-				/home/gopher/go/bin/mkcert: go1.16.15
+				/home/gopher/go/bin/mkcert: go1.19.1
 				\tpath\tfilippo.io/mkcert
-				\tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
-				\tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-				\tdep\tgolang.org/x/text\tv0.3.0\th1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-				\tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.0.0-20180114231543-2291e8f0f237\th1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
-
+				\tmod\tfilippo.io/mkcert\tv1.4.4\th1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
+				\tdep\tgolang.org/x/crypto\tv0.0.0-20220331220935-ae2d96664a29\th1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+				\tdep\tgolang.org/x/net\tv0.0.0-20220421235706-1d1ef9303861\th1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+				\tdep\tgolang.org/x/text\tv0.3.7\th1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+				\tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.2.0\th1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
 				"""
 			ComparisonOutput: """
-				/home/gopher/go/bin/mkcert: go1.16.15
+				/home/gopher/go/bin/mkcert: go1.19.1
 				\tpath\tfilippo.io/mkcert
-				\tmod\tfilippo.io/mkcert\tv1.4.2\th1:7mWofpFS4gzQS5bhE3KYBwzfceIPy2KJ4tMT31aPNeY=
-				\tdep\tgolang.org/x/net\tv0.0.0-20190620200207-3b0461eec859\th1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-				\tdep\tgolang.org/x/text\tv0.3.0\th1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
-				\tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.0.0-20180114231543-2291e8f0f237\th1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
-
+				\tmod\tfilippo.io/mkcert\tv1.4.4\th1:8eVbbwfVlaqUM7OwuftKc2nuYOoTDQWqsoXmzoXZdbc=
+				\tdep\tgolang.org/x/crypto\tv0.0.0-20220331220935-ae2d96664a29\th1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
+				\tdep\tgolang.org/x/net\tv0.0.0-20220421235706-1d1ef9303861\th1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+				\tdep\tgolang.org/x/text\tv0.3.7\th1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+				\tdep\tsoftware.sslmate.com/src/go-pkcs12\tv0.2.0\th1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
 				"""
 		}]
 	}
 }
-Hash: "c82a16030f644b76c51e45f0ce0b71c14b3cf34798230d29b0c90526d8522d1c"
+Hash: "d19823b04cae5f5be42889ac3f5d71ed8700c12a3ac6e15c47c8cbd3fafef345"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-09-using-staticcheck/go115_en_log.txt
+++ b/guides/2020-11-09-using-staticcheck/go115_en_log.txt
@@ -1,15 +1,16 @@
 $ go version
-go version go1.15.15 linux/amd64
-$ (cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)
-go: downloading honnef.co/go/tools v0.0.1-2020.1.6
-go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6
-go: downloading golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef
-go: downloading github.com/BurntSushi/toml v0.3.1
-go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+go version go1.19.1 linux/amd64
+$ go install honnef.co/go/tools/cmd/staticcheck@v0.3.3
+go: downloading honnef.co/go/tools v0.3.3
+go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+go: downloading golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
+go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+go: downloading github.com/BurntSushi/toml v0.4.1
+go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 $ which staticcheck
 /home/gopher/go/bin/staticcheck
 $ staticcheck -version
-staticcheck 2020.1.6
+staticcheck 2022.1.3 (v0.3.3)
 $ mkdir /home/gopher/pets
 $ cd /home/gopher/pets
 $ go mod init pets
@@ -61,6 +62,8 @@ Invalid Printf call
 Available since
     2019.2
 
+Online documentation
+    https://staticcheck.io/docs/checks#SA5009
 $ cat <<EOD > /home/gopher/pets/pets.go
 package pets
 

--- a/guides/2020-11-09-using-staticcheck/guide.cue
+++ b/guides/2020-11-09-using-staticcheck/guide.cue
@@ -6,7 +6,7 @@ import (
 
 Defs: {
 	_#commonDefs
-	staticcheck_version:      "v0.0.1-2020.1.6"
+	staticcheck_version:      "v0.3.3"
 	staticcheck_conf:         "staticcheck.conf"
 	staticcheck_st1000:       "ST1000"
 	staticcheck_sa4018:       "SA4018"
@@ -24,7 +24,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {
@@ -35,7 +35,7 @@ Steps: goversion: preguide.#Command & {
 
 Steps: staticcheck_install: preguide.#Command & {
 	Source: """
-		(cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@\(Defs.staticcheck_version))
+		go install honnef.co/go/tools/cmd/staticcheck@\(Defs.staticcheck_version)
 		"""
 }
 

--- a/guides/2020-11-09-using-staticcheck/out/gen_out.cue
+++ b/guides/2020-11-09-using-staticcheck/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -28,8 +28,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	staticcheck_install: {
@@ -41,23 +41,25 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
-			CmdStr:   "(cd $(mktemp -d); GO111MODULE=on go get honnef.co/go/tools/cmd/staticcheck@v0.0.1-2020.1.6)"
+			CmdStr:   "go install honnef.co/go/tools/cmd/staticcheck@v0.3.3"
 			ExitCode: 0
 			Output: """
-				go: downloading honnef.co/go/tools v0.0.1-2020.1.6
-				go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6
-				go: downloading golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef
-				go: downloading github.com/BurntSushi/toml v0.3.1
-				go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
+				go: downloading honnef.co/go/tools v0.3.3
+				go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+				go: downloading golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
+				go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+				go: downloading github.com/BurntSushi/toml v0.4.1
+				go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 
 				"""
 			ComparisonOutput: """
+				go: downloading honnef.co/go/tools v0.3.3
+				go: downloading golang.org/x/tools v0.1.11-0.20220513221640-090b14e8501f
+				go: downloading golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e
+				go: downloading golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+				go: downloading github.com/BurntSushi/toml v0.4.1
+				go: downloading golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
 
-				go: downloading github.com/BurntSushi/toml v0.3.1
-				go: downloading golang.org/x/tools v0.0.0-20200410194907-79a7a3126eef
-				go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
-				go: downloading honnef.co/go/tools v0.0.1-2020.1.6
-				go: found honnef.co/go/tools/cmd/staticcheck in honnef.co/go/tools v0.0.1-2020.1.6
 				"""
 		}]
 	}
@@ -94,11 +96,11 @@ Steps: {
 			CmdStr:   "staticcheck -version"
 			ExitCode: 0
 			Output: """
-				staticcheck 2020.1.6
+				staticcheck 2022.1.3 (v0.3.3)
 
 				"""
 			ComparisonOutput: """
-				staticcheck 2020.1.6
+				staticcheck 2022.1.3 (v0.3.3)
 
 				"""
 		}]
@@ -241,6 +243,8 @@ Steps: {
 				Available since
 				    2019.2
 
+				Online documentation
+				    https://staticcheck.io/docs/checks#SA5009
 
 				"""
 			ComparisonOutput: """
@@ -249,6 +253,8 @@ Steps: {
 				Available since
 				    2019.2
 
+				Online documentation
+				    https://staticcheck.io/docs/checks#SA5009
 
 				"""
 		}]
@@ -910,5 +916,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "66396cad683065b32470e992e2b449c499702986cff334556cdab46668d107d5"
+Hash: "29d51f4a617087a8662817a9ec8eae7670ad5825297397b2df912324ff2c1071"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
+++ b/guides/2020-11-12-working-with-private-modules/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ mkdir /home/gopher/public
 $ cd /home/gopher/public
 $ go mod init {{{.PUBLIC}}}
@@ -89,11 +89,11 @@ For more about environment variables, see 'go help environment'.
 $ go env -w GOPROXY=https://proxy.golang.org
 $ go get {{{.PUBLIC}}}
 go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
-go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
+go: added {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 $ go list -m -f {{.Version}} {{{.PUBLIC}}}
 v0.0.0-20060102150405-abcedf12345
 $ go get {{{.PRIVATE}}}
-go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
+go: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
 	server response:
 	not found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
@@ -102,58 +102,25 @@ go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{
 $ go env -w GOPROXY=
 $ go get {{{.PRIVATE}}}
 go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
+go: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
 	server response:
 	not found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 		fatal: could not read Username for 'https://gopher.live': terminal prompts disabled
 	Confirm the import path was entered correctly.
 	If this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
-$ go help module-private
-The go command defaults to downloading modules from the public Go module
-mirror at proxy.golang.org. It also defaults to validating downloaded modules,
-regardless of source, against the public Go checksum database at sum.golang.org.
-These defaults work well for publicly available source code.
+$ go help module-auth
+When the go command downloads a module zip file or go.mod file into the
+module cache, it computes a cryptographic hash and compares it with a known
+value to verify the file hasn't changed since it was first downloaded. Known
+hashes are stored in a file in the module root directory named go.sum. Hashes
+may also be downloaded from the checksum database depending on the values of
+GOSUMDB, GOPRIVATE, and GONOSUMDB.
 
-The GOPRIVATE environment variable controls which modules the go command
-considers to be private (not available publicly) and should therefore not use the
-proxy or checksum database. The variable is a comma-separated list of
-glob patterns (in the syntax of Go's path.Match) of module path prefixes.
-For example,
-
-	GOPRIVATE=*.corp.example.com,rsc.io/private
-
-causes the go command to treat as private any module with a path prefix
-matching either pattern, including git.corp.example.com/xyzzy, rsc.io/private,
-and rsc.io/private/quux.
-
-The GOPRIVATE environment variable may be used by other tools as well to
-identify non-public modules. For example, an editor could use GOPRIVATE
-to decide whether to hyperlink a package import to a godoc.org page.
-
-For fine-grained control over module download and validation, the GONOPROXY
-and GONOSUMDB environment variables accept the same kind of glob list
-and override GOPRIVATE for the specific decision of whether to use the proxy
-and checksum database, respectively.
-
-For example, if a company ran a module proxy serving private modules,
-users would configure go using:
-
-	GOPRIVATE=*.corp.example.com
-	GOPROXY=proxy.example.com
-	GONOPROXY=none
-
-This would tell the go command and other tools that modules beginning with
-a corp.example.com subdomain are private but that the company proxy should
-be used for downloading both public and private modules, because
-GONOPROXY has been set to a pattern that won't match any modules,
-overriding GOPRIVATE.
-
-The 'go env -w' command (see 'go help env') can be used to set these variables
-for future go command invocations.
+For details, see https://golang.org/ref/mod#authenticating.
 $ go env -w GOPRIVATE={{{.PRIVATE}}}
 $ go get {{{.PRIVATE}}}
 go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
+go: added {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
 $ go list -m -f {{.Version}} {{{.PRIVATE}}}
 v0.0.0-20060102150405-abcedf12345
 $ go run .

--- a/guides/2020-11-12-working-with-private-modules/guide.cue
+++ b/guides/2020-11-12-working-with-private-modules/guide.cue
@@ -34,7 +34,7 @@ Defs: {
 	gopher_dir:         "/home/gopher/\(gopher)"
 	gopher_go:          "\(gopher).go"
 	go_help_env:        "\(_#commonDefs.cmdgo.help) env"
-	go_help_modprivate: "\(_#commonDefs.cmdgo.help) module-private"
+	go_help_modprivate: "\(_#commonDefs.cmdgo.help) module-auth"
 }
 
 Scenarios: go115: preguide.#Scenario & {
@@ -43,7 +43,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {

--- a/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
+++ b/guides/2020-11-12-working-with-private-modules/out/gen_out.cue
@@ -81,8 +81,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -132,7 +132,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -155,8 +155,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	public_init: {
@@ -578,13 +578,13 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
+				go: added {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
 				go: downloading {{{.PUBLIC}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.PUBLIC}}} upgrade => v0.0.0-20060102150405-abcedf12345
 				"""
 		}]
 	}
@@ -622,7 +622,7 @@ Steps: {
 			CmdStr:   "go get {{{.PRIVATE}}}"
 			ExitCode: 1
 			Output: """
-				go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
+				go: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
 				\tserver response:
 				\tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
@@ -637,7 +637,7 @@ Steps: {
 				\tIf this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
 				\tnot found: module {{{.PRIVATE}}}: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\tserver response:
-				go get {{{.PRIVATE}}}: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
+				go: module {{{.PRIVATE}}}: reading https://proxy.golang.org/{{{.PRIVATE}}}/@v/list: 404 Not Found
 				"""
 		}]
 	}
@@ -669,7 +669,7 @@ Steps: {
 			ExitCode: 1
 			Output: """
 				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-				go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
+				go: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
 				\tserver response:
 				\tnot found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\t\tfatal: could not read Username for 'https://gopher.live': terminal prompts disabled
@@ -684,8 +684,8 @@ Steps: {
 				\tIf this is a private repository, see https://golang.org/doc/faq#git_https for additional information.
 				\tnot found: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: invalid version: git ls-remote -q origin in /tmp/gopath/pkg/mod/cache/vcs/0123456789abcdef: exit status 128:
 				\tserver response:
-				go get {{{.PRIVATE}}}: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
 				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
+				go: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: verifying module: {{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: reading https://sum.golang.org/lookup/{{{.PRIVATE}}}@v0.0.0-20060102150405-abcedf12345: 404 Not Found
 				"""
 		}]
 	}
@@ -698,94 +698,28 @@ Steps: {
 		Terminal:        "term1"
 		Stmts: [{
 			Negated:  false
-			CmdStr:   "go help module-private"
+			CmdStr:   "go help module-auth"
 			ExitCode: 0
 			Output: """
-				The go command defaults to downloading modules from the public Go module
-				mirror at proxy.golang.org. It also defaults to validating downloaded modules,
-				regardless of source, against the public Go checksum database at sum.golang.org.
-				These defaults work well for publicly available source code.
+				When the go command downloads a module zip file or go.mod file into the
+				module cache, it computes a cryptographic hash and compares it with a known
+				value to verify the file hasn't changed since it was first downloaded. Known
+				hashes are stored in a file in the module root directory named go.sum. Hashes
+				may also be downloaded from the checksum database depending on the values of
+				GOSUMDB, GOPRIVATE, and GONOSUMDB.
 
-				The GOPRIVATE environment variable controls which modules the go command
-				considers to be private (not available publicly) and should therefore not use the
-				proxy or checksum database. The variable is a comma-separated list of
-				glob patterns (in the syntax of Go's path.Match) of module path prefixes.
-				For example,
-
-				\tGOPRIVATE=*.corp.example.com,rsc.io/private
-
-				causes the go command to treat as private any module with a path prefix
-				matching either pattern, including git.corp.example.com/xyzzy, rsc.io/private,
-				and rsc.io/private/quux.
-
-				The GOPRIVATE environment variable may be used by other tools as well to
-				identify non-public modules. For example, an editor could use GOPRIVATE
-				to decide whether to hyperlink a package import to a godoc.org page.
-
-				For fine-grained control over module download and validation, the GONOPROXY
-				and GONOSUMDB environment variables accept the same kind of glob list
-				and override GOPRIVATE for the specific decision of whether to use the proxy
-				and checksum database, respectively.
-
-				For example, if a company ran a module proxy serving private modules,
-				users would configure go using:
-
-				\tGOPRIVATE=*.corp.example.com
-				\tGOPROXY=proxy.example.com
-				\tGONOPROXY=none
-
-				This would tell the go command and other tools that modules beginning with
-				a corp.example.com subdomain are private but that the company proxy should
-				be used for downloading both public and private modules, because
-				GONOPROXY has been set to a pattern that won't match any modules,
-				overriding GOPRIVATE.
-
-				The 'go env -w' command (see 'go help env') can be used to set these variables
-				for future go command invocations.
+				For details, see https://golang.org/ref/mod#authenticating.
 
 				"""
 			ComparisonOutput: """
-				The go command defaults to downloading modules from the public Go module
-				mirror at proxy.golang.org. It also defaults to validating downloaded modules,
-				regardless of source, against the public Go checksum database at sum.golang.org.
-				These defaults work well for publicly available source code.
+				When the go command downloads a module zip file or go.mod file into the
+				module cache, it computes a cryptographic hash and compares it with a known
+				value to verify the file hasn't changed since it was first downloaded. Known
+				hashes are stored in a file in the module root directory named go.sum. Hashes
+				may also be downloaded from the checksum database depending on the values of
+				GOSUMDB, GOPRIVATE, and GONOSUMDB.
 
-				The GOPRIVATE environment variable controls which modules the go command
-				considers to be private (not available publicly) and should therefore not use the
-				proxy or checksum database. The variable is a comma-separated list of
-				glob patterns (in the syntax of Go's path.Match) of module path prefixes.
-				For example,
-
-				\tGOPRIVATE=*.corp.example.com,rsc.io/private
-
-				causes the go command to treat as private any module with a path prefix
-				matching either pattern, including git.corp.example.com/xyzzy, rsc.io/private,
-				and rsc.io/private/quux.
-
-				The GOPRIVATE environment variable may be used by other tools as well to
-				identify non-public modules. For example, an editor could use GOPRIVATE
-				to decide whether to hyperlink a package import to a godoc.org page.
-
-				For fine-grained control over module download and validation, the GONOPROXY
-				and GONOSUMDB environment variables accept the same kind of glob list
-				and override GOPRIVATE for the specific decision of whether to use the proxy
-				and checksum database, respectively.
-
-				For example, if a company ran a module proxy serving private modules,
-				users would configure go using:
-
-				\tGOPRIVATE=*.corp.example.com
-				\tGOPROXY=proxy.example.com
-				\tGONOPROXY=none
-
-				This would tell the go command and other tools that modules beginning with
-				a corp.example.com subdomain are private but that the company proxy should
-				be used for downloading both public and private modules, because
-				GONOPROXY has been set to a pattern that won't match any modules,
-				overriding GOPRIVATE.
-
-				The 'go env -w' command (see 'go help env') can be used to set these variables
-				for future go command invocations.
+				For details, see https://golang.org/ref/mod#authenticating.
 
 				"""
 		}]
@@ -818,13 +752,13 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
+				go: added {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
 				go: downloading {{{.PRIVATE}}} v0.0.0-20060102150405-abcedf12345
-				go: {{{.PRIVATE}}} upgrade => v0.0.0-20060102150405-abcedf12345
 				"""
 		}]
 	}
@@ -874,5 +808,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "5aeb0e6f8ca108e4c4267463519d57c906181a6c92b666c64fd9ad55336cfc6a"
+Hash: "f2232199872cd3dccfd7a2084716cd499551087f9944f36db3bb491eb2265caa"
 Delims: ["{{{", "}}}"]

--- a/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
+++ b/guides/2020-11-19-major-version-repository-structure/go115_en_log.txt
@@ -1,5 +1,5 @@
 $ go version
-go version go1.15.15 linux/amd64
+go version go1.19.1 linux/amd64
 $ mkdir /home/gopher/branch
 $ cd /home/gopher/branch
 $ go mod init {{{.BRANCH}}}
@@ -126,12 +126,16 @@ func main() {
 EOD
 $ go get {{{.BRANCH}}}@v1.0.0
 go: downloading {{{.BRANCH}}} v1.0.0
+go: added {{{.BRANCH}}} v1.0.0
 $ go get {{{.BRANCH}}}/v2@v2.0.0
 go: downloading {{{.BRANCH}}}/v2 v2.0.0
+go: added {{{.BRANCH}}}/v2 v2.0.0
 $ go get {{{.SUBDIR}}}@v1.0.0
 go: downloading {{{.SUBDIR}}} v1.0.0
+go: added {{{.SUBDIR}}} v1.0.0
 $ go get {{{.SUBDIR}}}/v2@v2.0.0
 go: downloading {{{.SUBDIR}}}/v2 v2.0.0
+go: added {{{.SUBDIR}}}/v2 v2.0.0
 $ go run .
 branch.Message: branch v1
 branch/v2.Message: branch v2

--- a/guides/2020-11-19-major-version-repository-structure/guide.cue
+++ b/guides/2020-11-19-major-version-repository-structure/guide.cue
@@ -41,7 +41,7 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }
 
 Steps: goversion: preguide.#Command & {

--- a/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
+++ b/guides/2020-11-19-major-version-repository-structure/out/gen_out.cue
@@ -81,8 +81,8 @@ Presteps: [{
 		    },
 		    {
 		      "Path": "github.com/play-with-go/preguide",
-		      "Version": "v0.0.2-0.20220916045313-f81d11764005",
-		      "Sum": "h1:TozvtuERGrcqQhYM4thrishUY+QONu76GMskVpgQHBA=",
+		      "Version": "v0.0.2-0.20220918055127-cc4d80fbbfa7",
+		      "Sum": "h1:83MPB7IZes5I5o7Jc2r9JBgMqHaU+E8LjHv03xehSic=",
 		      "Replace": null
 		    },
 		    {
@@ -132,7 +132,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -155,8 +155,8 @@ Steps: {
 			Negated:          false
 			CmdStr:           "go version"
 			ExitCode:         0
-			Output:           "go version go1.15.15 linux/amd64"
-			ComparisonOutput: "go version go1.15.15 linux/amd64"
+			Output:           "go version go1.19.1 linux/amd64"
+			ComparisonOutput: "go version go1.19.1 linux/amd64"
 		}]
 	}
 	branch_init: {
@@ -724,10 +724,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.BRANCH}}} v1.0.0
+				go: added {{{.BRANCH}}} v1.0.0
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.BRANCH}}} v1.0.0
 				go: downloading {{{.BRANCH}}} v1.0.0
 				"""
 		}, {
@@ -736,10 +738,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.BRANCH}}}/v2 v2.0.0
+				go: added {{{.BRANCH}}}/v2 v2.0.0
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.BRANCH}}}/v2 v2.0.0
 				go: downloading {{{.BRANCH}}}/v2 v2.0.0
 				"""
 		}, {
@@ -748,10 +752,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.SUBDIR}}} v1.0.0
+				go: added {{{.SUBDIR}}} v1.0.0
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.SUBDIR}}} v1.0.0
 				go: downloading {{{.SUBDIR}}} v1.0.0
 				"""
 		}, {
@@ -760,10 +766,12 @@ Steps: {
 			ExitCode: 0
 			Output: """
 				go: downloading {{{.SUBDIR}}}/v2 v2.0.0
+				go: added {{{.SUBDIR}}}/v2 v2.0.0
 
 				"""
 			ComparisonOutput: """
 
+				go: added {{{.SUBDIR}}}/v2 v2.0.0
 				go: downloading {{{.SUBDIR}}}/v2 v2.0.0
 				"""
 		}]
@@ -796,5 +804,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "7dece9cb34390b221d2e98f2faa720ebb2fa859489ba010a8f63e3016d5121fb"
+Hash: "41c7f8744234fcd70be0eb280b0c4108d2f6b2cc6a46e7faccb6a8c9af7bba0a"
 Delims: ["{{{", "}}}"]

--- a/guides/2021-05-06-gosheffield-demo/guide.cue
+++ b/guides/2021-05-06-gosheffield-demo/guide.cue
@@ -28,5 +28,5 @@ Scenarios: go115: preguide.#Scenario & {
 
 Terminals: term1: preguide.#Terminal & {
 	Description: "The main terminal"
-	Scenarios: go115: Image: _#go115LatestImage
+	Scenarios: go115: Image: _#go119LatestImage
 }

--- a/guides/2021-05-06-gosheffield-demo/out/gen_out.cue
+++ b/guides/2021-05-06-gosheffield-demo/out/gen_out.cue
@@ -5,7 +5,7 @@ Terminals: [{
 	Description: "The main terminal"
 	Scenarios: {
 		go115: {
-			Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+			Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 		}
 	}
 }]
@@ -54,5 +54,5 @@ Steps: {
 		}]
 	}
 }
-Hash: "271f9cdbe52fe75c83acb8deecf95dc51ec068d641335bba20245003681ce10a"
+Hash: "09e26e2e121925fb298139537bf27cbb561802c097fd17a2c0d1be60fe318ffe"
 Delims: ["{{{", "}}}"]

--- a/guides/gen_guide_structures.cue
+++ b/guides/gen_guide_structures.cue
@@ -7,7 +7,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -40,7 +40,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -73,7 +73,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -91,7 +91,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -109,7 +109,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -138,7 +138,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go116: {
-				Image: "playwithgo/go1.16.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -167,7 +167,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -196,7 +196,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -225,7 +225,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -243,7 +243,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/installgo1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/installgo1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -261,7 +261,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]
@@ -294,7 +294,7 @@ package guides
 		Description: "The main terminal"
 		Scenarios: {
 			go115: {
-				Image: "playwithgo/go1.15.15:c14f40c289a17ef3817d7f82ea3ea2cfc3297713"
+				Image: "playwithgo/go1.19.1:5966cd5f1b8ef645576f95bcb19fff827d6ca560"
 			}
 		}
 	}]


### PR DESCRIPTION
(see commit message)

